### PR TITLE
Standardize commit messages, minor improvements and bug fixes

### DIFF
--- a/git_utils.py
+++ b/git_utils.py
@@ -5,13 +5,20 @@ from git import Repo
 
 import file_utils
 
-INITIAL_COMMIT_MESSAGE = "[Codeplain] Initial commit"
-BASE_FOLDER_COMMIT_MESSAGE = "[Codeplain] Initialize build with Base Folder content"
-REFACTORED_CODE_COMMIT_MESSAGE = "[Codeplain] Refactored code after implementing {}"
+FUNCTIONAL_REQUIREMENT_IMPLEMENTED_COMMIT_MESSAGE = (
+    "[Codeplain] Implemented code and unit tests for functional requirement {}"
+)
+REFACTORED_CODE_COMMIT_MESSAGE = "[Codeplain] Refactored code after implementing functional requirement {}"
 CONFORMANCE_TESTS_PASSED_COMMIT_MESSAGE = (
     "[Codeplain] Fixed issues in the implementation code identified during conformance testing"
 )
+
+# Following messages are used as checkpoints in the git history
+# Changing them will break backwards compatibility so change them with care
 FUNCTIONAL_REQUIREMENT_FINISHED_COMMIT_MESSAGE = "[Codeplain] Functional requirement ID (FRID):{} fully implemented"
+INITIAL_COMMIT_MESSAGE = "[Codeplain] Initial commit"
+BASE_FOLDER_COMMIT_MESSAGE = "[Codeplain] Initialize build with Base Folder content"
+
 
 RENDERED_FRID_MESSAGE = "Changes related to Functional requirement ID (FRID): {}"
 RENDER_ID_MESSAGE = "Render ID: {}"

--- a/plain2code_utils.py
+++ b/plain2code_utils.py
@@ -1,0 +1,20 @@
+import logging
+
+
+class RetryOnlyFilter(logging.Filter):
+    def filter(self, record):
+        # Allow all logs with level > DEBUG (i.e., INFO and above)
+        if record.levelno > logging.DEBUG:
+            return True
+        # For DEBUG logs, only allow if message matches retry-related patterns
+        msg = record.getMessage().lower()
+        return (
+            "retrying due to" in msg
+            or "raising timeout error" in msg
+            or "raising connection error" in msg
+            or "encountered exception" in msg
+            or "retrying request" in msg
+            or "retry left" in msg
+            or "1 retry left" in msg
+            or "retries left" in msg
+        )


### PR DESCRIPTION
This release standardizes commit messages in `build/` and `conformance_tests/` folders. Note that this update doesn't break backwards compatibility, so you can continue rendering from the current state.

Also, minor updates and bug fixes were introduced.