### PR TITLE
Add options to include destination folder for source and conformance test code

### DIFF
--- a/codeplain_REST_api.py
+++ b/codeplain_REST_api.py
@@ -213,6 +213,7 @@ class CodeplainAPI:
             "linked_resources": linked_resources,
             "existing_files_content": existing_files_content,
             "unittests_issue": unittests_issue,
+            "unittest_batch_id": run_state.unittest_batch_id,
         }
 
         return self.post_request(endpoint_url, headers, payload, run_state)

--- a/plain2code_state.py
+++ b/plain2code_state.py
@@ -62,15 +62,19 @@ class RunState:
     """Contains information about the identifiable state of the rendering process."""
 
     def __init__(self, replay_with: Optional[str] = None):
-        self.replay = replay_with is not None
+        self.replay: bool = replay_with is not None
         if replay_with:
-            self.render_id = replay_with
+            self.render_id: str = replay_with
         else:
-            self.render_id = str(uuid.uuid4())
-        self.call_count = 0
+            self.render_id: str = str(uuid.uuid4())
+        self.call_count: int = 0
+        self.unittest_batch_id: int = 0
 
     def increment_call_count(self):
         self.call_count += 1
+
+    def increment_unittest_batch_id(self):
+        self.unittest_batch_id += 1
 
     def to_dict(self):
         return {


### PR DESCRIPTION
With Plain-Git integration for source and conformance test code set in place, we're introducing the ability to utilize and commit the generated code in the existing repositories.

## Destination folder for the generated code

### You can copy the source code to source code destination folder

Through the plain2code CLI, you can now set `--copy-build` (bool) argument, telling if you want to copy the source code into destination folder after a successful rendering. By default, this code is copied into `dist/` folder, but you can manage this through `--build-dest` CLI parameter.

### You can copy the conformance tests to source code destination folder

Through the plain2code CLI, you can now set `--copy-conformance-tests` (bool) argument, telling if you want to copy the conformance test code into conformance test destination folder after a successful rendering. By default, this code is copied into `dist_conformance_tests/`, but you can manage this through `--conformance-tests-dest` CLI parameter.

## Other Changes

- Raising threshold for max conformance test runs to `20`, ensuring smoother code generation
- Minor bugfixes