### PR TITLE
Update tiktoken version to 0.12.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ python-liquid2==0.3.0
 mistletoe==1.3.0
 requests==2.32.3
 rich==13.9.4
-tiktoken==0.9.0
+tiktoken==0.12.0
 PyYAML==6.0.2
 gitpython==3.1.42
 transitions==0.9.3


### PR DESCRIPTION
The `tiktoken` version `0.9.0` doesn't support Python 3.14, so a version bump for `tiktoken` was needed.