### PR TITLE
Refactor and simplify exception handling for plain syntax error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ dist
 *.egg-info
 
 .env
+
+.coverage

--- a/codeplain_REST_api.py
+++ b/codeplain_REST_api.py
@@ -65,12 +65,6 @@ class CodeplainAPI:
                     if response_json["error_code"] == "PlainSyntaxError":
                         raise plain2code_exceptions.PlainSyntaxError(response_json["message"])
 
-                    if response_json["error_code"] == "OnlyRelativeLinksAllowed":
-                        raise plain2code_exceptions.OnlyRelativeLinksAllowed(response_json["message"])
-
-                    if response_json["error_code"] == "LinkMustHaveTextSpecified":
-                        raise plain2code_exceptions.LinkMustHaveTextSpecified(response_json["message"])
-
                     if response_json["error_code"] == "NoRenderFound":
                         raise plain2code_exceptions.NoRenderFound(response_json["message"])
 

--- a/git_utils.py
+++ b/git_utils.py
@@ -4,6 +4,7 @@ from typing import Optional, Union
 from git import Repo
 
 import file_utils
+from plain2code_exceptions import InvalidGitRepositoryError
 
 FUNCTIONAL_REQUIREMENT_IMPLEMENTED_COMMIT_MESSAGE = (
     "[Codeplain] Implemented code and unit tests for functional requirement {}"
@@ -23,12 +24,6 @@ BASE_FOLDER_COMMIT_MESSAGE = "[Codeplain] Initialize build with Base Folder cont
 RENDERED_FRID_MESSAGE = "Changes related to Functional requirement ID (FRID): {}"
 MODULE_NAME_MESSAGE = "Module name: {}"
 RENDER_ID_MESSAGE = "Render ID: {}"
-
-
-class InvalidGitRepositoryError(Exception):
-    """Raised when the git repository is in an invalid state."""
-
-    pass
 
 
 def _get_full_commit_message(message, module_name, frid, render_id) -> str:

--- a/plain2code.py
+++ b/plain2code.py
@@ -17,13 +17,7 @@ from event_bus import EventBus
 from module_renderer import ModuleRenderer
 from plain2code_arguments import parse_arguments
 from plain2code_console import console
-from plain2code_exceptions import (
-    InvalidFridArgument,
-    InvalidPlainFileExtension,
-    MissingAPIKey,
-    PlainModuleNotFound,
-    PlainSyntaxError,
-)
+from plain2code_exceptions import InvalidFridArgument, MissingAPIKey, PlainSyntaxError
 from plain2code_logger import (
     CrashLogHandler,
     IndentedFormatter,
@@ -237,9 +231,6 @@ def main():
         console.error(f"File not found: {str(e)}\n")
         console.debug(f"Render ID: {run_state.render_id}")
         dump_crash_logs(args)
-    except InvalidPlainFileExtension as e:
-        console.error(f"Invalid plain file extension: {str(e)}\n")
-        dump_crash_logs(args)
     except TemplateNotFoundError as e:
         console.error(f"Template not found: {str(e)}\n")
         console.error(system_config.get_error_message("template_not_found"))
@@ -258,9 +249,6 @@ def main():
         dump_crash_logs(args)
     except MissingAPIKey as e:
         console.error(f"Missing API key: {str(e)}\n")
-    except PlainModuleNotFound as e:
-        console.error(f"Module not found: {str(e)}\n")
-        dump_crash_logs(args)
     except Exception as e:
         console.error(f"Error rendering plain code: {str(e)}\n")
         console.debug(f"Render ID: {run_state.render_id}")

--- a/plain2code.py
+++ b/plain2code.py
@@ -17,7 +17,13 @@ from event_bus import EventBus
 from module_renderer import ModuleRenderer
 from plain2code_arguments import parse_arguments
 from plain2code_console import console
-from plain2code_exceptions import MissingAPIKey, PlainSyntaxError
+from plain2code_exceptions import (
+    InvalidFridArgument,
+    InvalidPlainFileExtension,
+    MissingAPIKey,
+    PlainModuleNotFound,
+    PlainSyntaxError,
+)
 from plain2code_logger import (
     CrashLogHandler,
     IndentedFormatter,
@@ -44,10 +50,6 @@ MAX_ISSUE_LENGTH = 10000  # Characters.
 
 UNRECOVERABLE_ERROR_EXIT_CODES = [69]
 TIMEOUT_ERROR_EXIT_CODE = 124
-
-
-class InvalidFridArgument(Exception):
-    pass
 
 
 def get_render_range(render_range, plain_source):
@@ -227,23 +229,23 @@ def main():
 
         render(args, run_state, codeplain_api, event_bus)
     except InvalidFridArgument as e:
-        console.error(f"Error rendering plain code: {str(e)}.\n")
+        console.error(f"Invalid FRID argument: {str(e)}.\n")
         # No need to print render ID since this error is going to be thrown at the very start so user will be able to
         # see the render ID that's printed at the very start of the rendering process.
         dump_crash_logs(args)
     except FileNotFoundError as e:
-        console.error(f"Error rendering plain code: {str(e)}\n")
+        console.error(f"File not found: {str(e)}\n")
         console.debug(f"Render ID: {run_state.render_id}")
         dump_crash_logs(args)
-    except plain_file.InvalidPlainFileExtension as e:
-        console.error(f"Error rendering plain code: {str(e)}\n")
+    except InvalidPlainFileExtension as e:
+        console.error(f"Invalid plain file extension: {str(e)}\n")
         dump_crash_logs(args)
     except TemplateNotFoundError as e:
-        console.error(f"Error: Template not found: {str(e)}\n")
+        console.error(f"Template not found: {str(e)}\n")
         console.error(system_config.get_error_message("template_not_found"))
         dump_crash_logs(args)
     except PlainSyntaxError as e:
-        console.error(f"Error rendering plain code: {str(e)}\n")
+        console.error(f"Plain syntax error: {str(e)}\n")
         dump_crash_logs(args)
     except KeyboardInterrupt:
         console.error("Keyboard interrupt")
@@ -256,6 +258,9 @@ def main():
         dump_crash_logs(args)
     except MissingAPIKey as e:
         console.error(f"Missing API key: {str(e)}\n")
+    except PlainModuleNotFound as e:
+        console.error(f"Module not found: {str(e)}\n")
+        dump_crash_logs(args)
     except Exception as e:
         console.error(f"Error rendering plain code: {str(e)}\n")
         console.debug(f"Render ID: {run_state.render_id}")

--- a/plain2code_exceptions.py
+++ b/plain2code_exceptions.py
@@ -25,22 +25,6 @@ class PlainSyntaxError(Exception):
     pass
 
 
-class OnlyRelativeLinksAllowed(PlainSyntaxError):
-    pass
-
-
-class LinkMustHaveTextSpecified(PlainSyntaxError):
-    pass
-
-
-class InvalidPlainFileExtension(PlainSyntaxError):
-    pass
-
-
-class PlainModuleNotFound(PlainSyntaxError):
-    pass
-
-
 class NoRenderFound(Exception):
     pass
 

--- a/plain2code_exceptions.py
+++ b/plain2code_exceptions.py
@@ -25,11 +25,19 @@ class PlainSyntaxError(Exception):
     pass
 
 
-class OnlyRelativeLinksAllowed(Exception):
+class OnlyRelativeLinksAllowed(PlainSyntaxError):
     pass
 
 
-class LinkMustHaveTextSpecified(Exception):
+class LinkMustHaveTextSpecified(PlainSyntaxError):
+    pass
+
+
+class InvalidPlainFileExtension(PlainSyntaxError):
+    pass
+
+
+class PlainModuleNotFound(PlainSyntaxError):
     pass
 
 
@@ -46,4 +54,22 @@ class UnexpectedState(Exception):
 
 
 class MissingAPIKey(Exception):
+    pass
+
+
+class InvalidFridArgument(Exception):
+    pass
+
+
+class InvalidGitRepositoryError(Exception):
+    """Raised when the git repository is in an invalid state."""
+
+    pass
+
+
+class InvalidLiquidVariableName(Exception):
+    pass
+
+
+class ModuleDoesNotExistError(Exception):
     pass

--- a/plain_file.py
+++ b/plain_file.py
@@ -17,7 +17,13 @@ from mistletoe.utils import traverse
 import concept_utils
 import file_utils
 import plain_spec
-from plain2code_exceptions import PlainSyntaxError
+from plain2code_exceptions import (
+    InvalidPlainFileExtension,
+    LinkMustHaveTextSpecified,
+    OnlyRelativeLinksAllowed,
+    PlainModuleNotFound,
+    PlainSyntaxError,
+)
 from plain2code_nodes import Plain2CodeIncludeTag, Plain2CodeLoaderMixin
 
 RESOURCE_MARKER = "[resource]"
@@ -42,22 +48,6 @@ class PlainFileParseResult:
     plain_source_obj: frontmatter.Post
     required_modules: list[str]
     required_concepts: list[str]
-
-
-class OnlyRelativeLinksAllowed(Exception):
-    pass
-
-
-class LinkMustHaveTextSpecified(Exception):
-    pass
-
-
-class InvalidPlainFileExtension(Exception):
-    pass
-
-
-class PlainModuleNotFound(Exception):
-    pass
 
 
 class PlainRenderer(MarkdownRenderer):

--- a/plain_file.py
+++ b/plain_file.py
@@ -661,7 +661,7 @@ def plain_file_parser(  # noqa: C901
             modules_trace=[],
         )
     except PlainModuleNotFound as e:
-        raise PlainSyntaxError(e.message)
+        raise PlainSyntaxError(f"Module not found: {str(e)}.")
 
     if len(plain_file_parse_result.required_concepts) > 0:
         missing_required_concepts_msg = "Missing required concepts: "

--- a/plain_modules.py
+++ b/plain_modules.py
@@ -7,6 +7,7 @@ from git.exc import NoSuchPathError
 
 import git_utils
 import plain_spec
+from plain2code_exceptions import ModuleDoesNotExistError
 from render_machine.implementation_code_helpers import ImplementationCodeHelpers
 
 CODEPLAIN_MEMORY_SUBFOLDER = ".memory"
@@ -14,10 +15,6 @@ CODEPLAIN_METADATA_FOLDER = ".codeplain"
 MODULE_METADATA_FILENAME = "module_metadata.json"
 MODULE_FUNCTIONALITIES = "functionalities"
 REQUIRED_MODULES_FUNCTIONALITIES = "required_modules_functionalities"
-
-
-class ModuleDoesNotExistError(Exception):
-    pass
 
 
 class PlainModule:

--- a/plain_spec.py
+++ b/plain_spec.py
@@ -5,6 +5,8 @@ from typing import Optional
 
 from liquid2.filter import with_context
 
+from plain2code_exceptions import InvalidLiquidVariableName
+
 DEFINITIONS = "definitions"
 NON_FUNCTIONAL_REQUIREMENTS = "technical specs"
 TEST_REQUIREMENTS = "test specs"
@@ -21,10 +23,6 @@ ALLOWED_SPECIFICATION_HEADINGS = [
 ]
 
 ALLOWED_IMPORT_SPECIFICATION_HEADINGS = [DEFINITIONS, NON_FUNCTIONAL_REQUIREMENTS, TEST_REQUIREMENTS]
-
-
-class InvalidLiquidVariableName(Exception):
-    pass
 
 
 def collect_specification_linked_resources(specification, specification_heading, linked_resources_list):

--- a/tests/test_plainfile.py
+++ b/tests/test_plainfile.py
@@ -6,7 +6,7 @@ from mistletoe.span_token import Emphasis, RawText, Strong
 
 import plain_file
 import plain_spec
-from plain2code_exceptions import PlainSyntaxError
+from plain2code_exceptions import InvalidPlainFileExtension, PlainSyntaxError
 from plain_file import process_acceptance_tests
 
 
@@ -267,5 +267,5 @@ def test_psart_with_duplicate_acceptance_test_heading():
 
 
 def test_invalid_plain_file_extension():
-    with pytest.raises(plain_file.InvalidPlainFileExtension):
+    with pytest.raises(InvalidPlainFileExtension):
         plain_file.plain_file_parser("test.txt", [])

--- a/tests/test_plainfile.py
+++ b/tests/test_plainfile.py
@@ -6,7 +6,7 @@ from mistletoe.span_token import Emphasis, RawText, Strong
 
 import plain_file
 import plain_spec
-from plain2code_exceptions import InvalidPlainFileExtension, PlainSyntaxError
+from plain2code_exceptions import PlainSyntaxError
 from plain_file import process_acceptance_tests
 
 
@@ -267,5 +267,5 @@ def test_psart_with_duplicate_acceptance_test_heading():
 
 
 def test_invalid_plain_file_extension():
-    with pytest.raises(InvalidPlainFileExtension):
+    with pytest.raises(PlainSyntaxError):
         plain_file.plain_file_parser("test.txt", [])

--- a/tests/test_requires.py
+++ b/tests/test_requires.py
@@ -1,10 +1,11 @@
 import pytest
 
 import plain_file
+from plain2code_exceptions import PlainSyntaxError
 
 
 def test_non_existent_require(get_test_data_path):
-    with pytest.raises(Exception, match="Required module not found"):
+    with pytest.raises(PlainSyntaxError, match="Module does not exist"):
         plain_file.plain_file_parser("non_existent_require.plain", [get_test_data_path("data/requires")])
 
 


### PR DESCRIPTION
This PR has 3 separate commits that can be reviewed independently:

- 6957c200f558655a57d825327e56f941946216cc - there is no property "message", and this is why we get error @dusano described in https://github.com/Codeplain-ai/plain2code_client/issues/56
- 5268b90cd954acf3b1556211047282016976ffef - I noticed that errors are scattered all accross the codebase, and I moved them all to `plain2code_exceptions.py`
- 109a1d3b249012d0591fd03e211767dd3a5ad41c - IMHO, I think some of distinct errors are not serving us well, so I removed them.

Because `plain_file.py` and `plain_exceptions.py` are shared, this also requires a corresponding sever-side update.