### PR TITLE
Replace the bash subshell with a fresh instance of the user's default shell 

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -221,8 +221,11 @@ echo -e "${GRAY}─────────────────────�
 echo ""
 echo -e "  thank you for using *codeplain!"
 echo ""
-echo ""
 echo -e "  learn more at ${YELLOW}https://plainlang.org/${NC}"
 echo ""
 echo -e "  ${GREEN}happy development!${NC} 🚀"
 echo ""
+
+# Replace this subshell with a fresh shell that has the new environment
+# Reconnect stdin to terminal (needed when running via curl | bash)
+exec "$SHELL" < /dev/tty


### PR DESCRIPTION
running scripts with | bash runs the script in a subshell.

That means that the export is not available when you exit the script.

Now exec "$SHELL" < /dev/tty reconnects stdin to the terminal before starting the new shell. This works correctly whether the script is run via:
./install.sh
bash install.sh
curl -fsSL https://codeplain.ai/install.sh | bash