### PR TITLE
Fix setting refactoring substates

### DIFF
--- a/tui/state_handlers.py
+++ b/tui/state_handlers.py
@@ -165,7 +165,7 @@ class RefactoringHandler(StateHandler):
             elif segments[3] == States.UNIT_TESTS_FAILED.value:
                 update_progress_item_substates(
                     self.tui,
-                    TUIComponents.FRID_PROGRESS_UNIT_TEST.value,
+                    TUIComponents.FRID_PROGRESS_REFACTORING.value,
                     [Substate("Refactoring code", children=[Substate("Fixing unit tests")])],
                 )
 


### PR DESCRIPTION
We had a bug in setting previous substates:

<img width="897" height="255" alt="image" src="https://github.com/user-attachments/assets/dfe768e1-cacf-42ce-8c2b-0ce5903ed12f" />

We assigned "refactoring and fixing unittest substates" to the wrong root widget (unit tests, but they should be assigned to refactoring).

This change should not be breaking in any way and is save to merge now.
