### PR TITLE
Display module does not exist error when module does not exist

### DIFF
--- a/plain2code.py
+++ b/plain2code.py
@@ -28,6 +28,7 @@ from plain2code_exceptions import (
     MissingAPIKey,
     MissingPreviousFunctionalitiesError,
     MissingResource,
+    ModuleDoesNotExistError,
     NetworkConnectionError,
     OutdatedClientVersion,
     PlainSyntaxError,
@@ -318,6 +319,9 @@ def main():  # noqa: C901
         exc_info = sys.exc_info()
         console.error(f"Connection error: {str(e)}\n")
         console.error("Please check that your internet connection is working.")
+    except ModuleDoesNotExistError as e:
+        exc_info = sys.exc_info()
+        console.error(f"Module does not exist: {str(e)}\n")
         console.debug(f"Render ID: {run_state.render_id}")
     except Exception as e:
         exc_info = sys.exc_info()

--- a/plain_file.py
+++ b/plain_file.py
@@ -17,7 +17,7 @@ from mistletoe.utils import traverse
 import concept_utils
 import file_utils
 import plain_spec
-from plain2code_exceptions import PlainSyntaxError
+from plain2code_exceptions import ModuleDoesNotExistError, PlainSyntaxError
 from plain2code_nodes import Plain2CodeIncludeTag, Plain2CodeLoaderMixin
 
 RESOURCE_MARKER = "[resource]"
@@ -513,7 +513,7 @@ def parse_plain_source(  # noqa: C901
 def read_module_plain_source(module_name: str, template_dirs: list[str]) -> str:
     plain_source_text = file_utils.open_from(template_dirs, module_name + PLAIN_SOURCE_FILE_EXTENSION)
     if plain_source_text is None:
-        raise PlainSyntaxError(f"Module does not exist ({module_name}).")
+        raise ModuleDoesNotExistError(f"Module does not exist ({module_name}).")
     return plain_source_text
 
 

--- a/tests/test_requires.py
+++ b/tests/test_requires.py
@@ -1,11 +1,11 @@
 import pytest
 
 import plain_file
-from plain2code_exceptions import PlainSyntaxError
+from plain2code_exceptions import ModuleDoesNotExistError
 
 
 def test_non_existent_require(get_test_data_path):
-    with pytest.raises(PlainSyntaxError, match="Module does not exist"):
+    with pytest.raises(ModuleDoesNotExistError, match="Module does not exist"):
         plain_file.plain_file_parser("non_existent_require.plain", [get_test_data_path("data/requires")])
 
 


### PR DESCRIPTION
Let's say you tried to render a module that does not exist

- Before: Raise and display plain sytax error
- Now: Raise and propagate "module not found error"

This also took changes on the server

<img width="1158" height="108" alt="image" src="https://github.com/user-attachments/assets/b3412a7f-eb13-4ef0-ade8-f3074414eae6" />
