### PR TITLE
Remove verifying system requirements at runtime

### DIFF
--- a/config/system_config.yaml
+++ b/config/system_config.yaml
@@ -1,22 +1,5 @@
 client_version: "0.17.0"
 
-system_requirements:
-  timeout:
-    command: timeout
-    error_message: |
-      Error: Required system command 'timeout' is not available.
-      This command is needed to enforce time limits on test execution.
-
-      To install the timeout command:
-      - On Linux: Install coreutils package
-        - Debian/Ubuntu: sudo apt-get install coreutils
-        - CentOS/RHEL: sudo yum install coreutils
-        - Fedora: sudo dnf install coreutils
-      - On macOS:
-        - Using Homebrew: brew install coreutils
-        - Using MacPorts: port install coreutils
-      - On Windows: Use Windows Subsystem for Linux (WSL), Cygwin, or Git Bash
-
 error_messages:
   template_not_found:
     message: |

--- a/plain2code.py
+++ b/plain2code.py
@@ -185,9 +185,6 @@ def _check_connection(codeplainAPI):
 
 
 def render(args, run_state: RunState, codeplain_api, event_bus: EventBus):  # noqa: C901
-    # Check system requirements before proceeding
-    system_config.verify_requirements()
-
     template_dirs = file_utils.get_template_directories(args.filename, args.template_dir, DEFAULT_TEMPLATE_DIRS)
 
     console.info(f"Rendering {args.filename} to target code.")

--- a/system_config.py
+++ b/system_config.py
@@ -1,5 +1,4 @@
 import importlib.resources
-import shutil
 import sys
 
 import yaml
@@ -14,8 +13,6 @@ class SystemConfig:
         self.config = self._load_config()
         if "client_version" not in self.config:
             raise KeyError("Missing 'client_version' in system_config.yaml")
-        if "system_requirements" not in self.config:
-            raise KeyError("Missing 'system_requirements' section in system_config.yaml")
         if "error_messages" not in self.config:
             raise KeyError("Missing 'error_messages' section in system_config.yaml")
 
@@ -33,13 +30,6 @@ class SystemConfig:
         except Exception as e:
             console.error(f"Failed to load system configuration: {e}")
             sys.exit(69)
-
-    def verify_requirements(self):
-        """Verify all system requirements are met."""
-        for req_data in self.requirements.values():
-            if not shutil.which(req_data["command"]):
-                console.error(req_data["error_message"])
-                sys.exit(69)
 
     def get_error_message(self, message_key, **kwargs):
         """Get a formatted error message by its key."""


### PR DESCRIPTION
With https://github.com/Codeplain-ai/codeplain/pull/80, we don't have to have a hard constraint of requiring `timeout`. 

Either way, it doesn't make sense for `timeout` to be tied to codeplain CLI.