### PR TITLE
Removing system requirements check leftovers

### DIFF
--- a/system_config.py
+++ b/system_config.py
@@ -17,7 +17,6 @@ class SystemConfig:
             raise KeyError("Missing 'error_messages' section in system_config.yaml")
 
         self.client_version = self.config["client_version"]
-        self.requirements = self.config["system_requirements"]
         self.error_messages = self.config["error_messages"]
 
     def _load_config(self):


### PR DESCRIPTION
Got the following error, cause this was checking for the presence of "system_requirements" which were previously removed.
```
Traceback (most recent call last):
  File "/home/vitjan/codeplain/plain2code.py", line 43, in <module>
    from system_config import system_config
  File "/home/vitjan/codeplain/system_config.py", line 42, in <module>
    system_config = SystemConfig()
                    ^^^^^^^^^^^^^^
  File "/home/vitjan/codeplain/system_config.py", line 20, in __init__
    self.requirements = self.config["system_requirements"]
```