### PR TITLE
TUI "render completed message": Improve and rearrange

### DIFF
--- a/module_renderer.py
+++ b/module_renderer.py
@@ -260,4 +260,6 @@ class ModuleRenderer:
         self.loaded_modules = list[PlainModule]()
         _, _, rendering_failed = self._render_module(self.filename, self.render_range, True)
         if not rendering_failed:
-            self.event_bus.publish(RenderCompleted())
+            # Get the last module that completed rendering
+            last_module_name = self.loaded_modules[-1].name if self.loaded_modules else ""
+            self.event_bus.publish(RenderCompleted(module_name=last_module_name, build_folder=self.args.build_folder))

--- a/plain2code_events.py
+++ b/plain2code_events.py
@@ -24,10 +24,12 @@ class RenderContextSnapshot:
     module_name: str
 
 
+@dataclass
 class RenderCompleted(BaseEvent):
     """Event emitted when rendering completes successfully."""
 
-    pass
+    module_name: str
+    build_folder: str
 
 
 @dataclass

--- a/tui/plain2code_tui.py
+++ b/tui/plain2code_tui.py
@@ -272,9 +272,9 @@ class Plain2CodeTUI(App):
 
         self._state_completion_handler.handle(segments, snapshot, previous_state_segments)
 
-    def on_render_completed(self, _event: RenderCompleted):
+    def on_render_completed(self, event: RenderCompleted):
         """Handle successful render completion."""
-        self._render_success_handler.handle()
+        self._render_success_handler.handle(event.module_name, event.build_folder)
 
     def on_render_failed(self, event: RenderFailed):
         """Handle render failure."""

--- a/tui/state_handlers.py
+++ b/tui/state_handlers.py
@@ -289,7 +289,7 @@ class FridFullyImplementedHandler(StateHandler):
 
 
 class RenderSuccessHandler:
-    """Handler for ERROR state."""
+    """Handler for successful render completion."""
 
     def __init__(self, tui):
         """Initialize handler with TUI instance.
@@ -299,9 +299,14 @@ class RenderSuccessHandler:
         """
         self.tui = tui
 
-    def handle(self) -> None:
-        """Handle ERROR state."""
-        display_success_message(self.tui)
+    def handle(self, module_name: str, build_folder: str) -> None:
+        """Handle successful render completion.
+
+        Args:
+            module_name: Name of the last module that completed rendering
+            build_folder: The build folder path
+        """
+        display_success_message(self.tui, module_name, build_folder)
 
 
 class RenderErrorHandler:

--- a/tui/widget_helpers.py
+++ b/tui/widget_helpers.py
@@ -1,5 +1,6 @@
 """Widget update helper utilities for Plain2Code TUI."""
 
+import os
 from datetime import datetime
 
 from textual.css.query import NoMatches
@@ -97,10 +98,20 @@ def get_frid_progress(tui) -> FRIDProgress:
     return tui.query_one(f"#{TUIComponents.FRID_PROGRESS.value}", FRIDProgress)
 
 
-def display_success_message(tui):
+def display_success_message(tui, module_name: str, build_folder: str):
+    """Display success message with code location and exit instructions.
+
+    Args:
+        tui: The Plain2CodeTUI instance
+        module_name: Name of the module that was rendered
+        build_folder: The build folder path
+    """
+
+    code_location = os.path.join(build_folder, module_name)
+    message = f"[#79FC96]✓ Rendering finished![/#79FC96] [#888888](ctrl+c to exit)[/#888888]\n[#888888]Generated code: {code_location}[/#888888] "
+
     widget: Static = tui.query_one(f"#{TUIComponents.RENDER_STATUS_WIDGET.value}", Static)
-    widget.add_class("success")
-    widget.update("✓ Rendering finished!")
+    widget.update(message)
 
 
 def set_frid_progress_to_stopped(tui):


### PR DESCRIPTION
## Changes:

- Move `codeplain-header` widget to the bottom
- Improve success message of the rendering. Now we communicate the following information:
  - How to exit the TUI
  - Where can the user find fully generated code

## Before

<img width="1338" height="468" alt="Screenshot 2026-02-04 at 20 40 47" src="https://github.com/user-attachments/assets/ed18c111-99c6-4b44-96a0-2356f0ac06d6" />

## After

<img width="1290" height="499" alt="image" src="https://github.com/user-attachments/assets/6db5ce0d-f822-4dcd-beb2-dd328399ffc6" />
