### PR TITLE
Display `dist/` folder on the TUI

### DIFF
--- a/module_renderer.py
+++ b/module_renderer.py
@@ -261,5 +261,10 @@ class ModuleRenderer:
         _, _, rendering_failed = self._render_module(self.filename, self.render_range, True)
         if not rendering_failed:
             # Get the last module that completed rendering
-            last_module_name = self.loaded_modules[-1].name if self.loaded_modules else ""
-            self.event_bus.publish(RenderCompleted(module_name=last_module_name, build_folder=self.args.build_folder))
+            if self.args.copy_build:
+                rendered_code_path = f"{self.args.build_dest}/"
+            else:
+                last_module_name = self.filename.replace(plain_file.PLAIN_SOURCE_FILE_EXTENSION, "")
+                rendered_code_path = f"{os.path.join(self.args.build_folder, last_module_name)}/"
+
+            self.event_bus.publish(RenderCompleted(rendered_code_path=rendered_code_path))

--- a/plain2code_events.py
+++ b/plain2code_events.py
@@ -28,8 +28,7 @@ class RenderContextSnapshot:
 class RenderCompleted(BaseEvent):
     """Event emitted when rendering completes successfully."""
 
-    module_name: str
-    build_folder: str
+    rendered_code_path: str
 
 
 @dataclass

--- a/tui/plain2code_tui.py
+++ b/tui/plain2code_tui.py
@@ -274,7 +274,7 @@ class Plain2CodeTUI(App):
 
     def on_render_completed(self, event: RenderCompleted):
         """Handle successful render completion."""
-        self._render_success_handler.handle(event.module_name, event.build_folder)
+        self._render_success_handler.handle(event.rendered_code_path)
 
     def on_render_failed(self, event: RenderFailed):
         """Handle render failure."""

--- a/tui/state_handlers.py
+++ b/tui/state_handlers.py
@@ -299,14 +299,13 @@ class RenderSuccessHandler:
         """
         self.tui = tui
 
-    def handle(self, module_name: str, build_folder: str) -> None:
+    def handle(self, rendered_code_path: str) -> None:
         """Handle successful render completion.
 
         Args:
-            module_name: Name of the last module that completed rendering
-            build_folder: The build folder path
+            rendered_code_path: The path to the rendered code
         """
-        display_success_message(self.tui, module_name, build_folder)
+        display_success_message(self.tui, rendered_code_path)
 
 
 class RenderErrorHandler:

--- a/tui/widget_helpers.py
+++ b/tui/widget_helpers.py
@@ -1,6 +1,5 @@
 """Widget update helper utilities for Plain2Code TUI."""
 
-import os
 from datetime import datetime
 
 from textual.css.query import NoMatches
@@ -98,17 +97,15 @@ def get_frid_progress(tui) -> FRIDProgress:
     return tui.query_one(f"#{TUIComponents.FRID_PROGRESS.value}", FRIDProgress)
 
 
-def display_success_message(tui, module_name: str, build_folder: str):
+def display_success_message(tui, rendered_code_path: str):
     """Display success message with code location and exit instructions.
 
     Args:
         tui: The Plain2CodeTUI instance
-        module_name: Name of the module that was rendered
-        build_folder: The build folder path
+        rendered_code_path: The path to the rendered code
     """
 
-    code_location = os.path.join(build_folder, module_name)
-    message = f"[#79FC96]✓ Rendering finished![/#79FC96] [#888888](ctrl+c to exit)[/#888888]\n[#888888]Generated code: {code_location}[/#888888] "
+    message = f"[#79FC96]✓ Rendering finished![/#79FC96] [#888888](ctrl+c to exit)[/#888888]\n[#888888]Generated code: {rendered_code_path}[/#888888] "
 
     widget: Static = tui.query_one(f"#{TUIComponents.RENDER_STATUS_WIDGET.value}", Static)
     widget.update(message)


### PR DESCRIPTION
## Summary

If `copy-build` is provided, display the build directory instead of path to the module

In the examples below, I provided `build-dist: true`.

## Before

<img width="899" height="512" alt="before" src="https://github.com/user-attachments/assets/6314ac15-328a-4f2c-9e1f-1a70d70c8646" />

## After

<img width="899" height="512" alt="after" src="https://github.com/user-attachments/assets/4c5b420b-328d-4eab-80fc-5cf81bd79897" />
