### PR TITLE
Chore: Bump textual version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,10 +22,10 @@ dependencies = [
     "PyYAML==6.0.2",
     "gitpython==3.1.42",
     "transitions==0.9.3",
-    "textual==1.0.0",
+    "textual>=1.0.0",
     "rich==14.2.0",
     "python-frontmatter==1.1.0",
-    "networkx==3.6.1"
+    "networkx==3.6.1",
 ]
 
 [project.optional-dependencies]
@@ -46,7 +46,7 @@ include = [
     "config/**/*",
     "render_machine/**/*",
     "standard_template_library/**/*",
-    "tui/**/*"
+    "tui/**/*",
 ]
 
 [tool.black]

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ tiktoken==0.12.0
 PyYAML==6.0.2
 gitpython==3.1.42
 pytest==8.3.4
-textual==1.0.0
+textual>=1.0.0
 networkx==3.6.1
 transitions==0.9.3
 


### PR DESCRIPTION
✅ Verified that there were no breaking changes with bumped version of textual.

Needed this to implement mark + copy functionality