### PR TITLE
Fix TUI footer text spacing and wording

### DIFF
--- a/tui/components.py
+++ b/tui/components.py
@@ -24,7 +24,7 @@ class CustomFooter(Horizontal):
         self._footer_text_widget = Static(self.FOOTER_TEXT, classes="custom-footer-text")
         yield self._footer_text_widget
         if self.render_id:
-            yield Static(f"render id: {self.render_id}", classes="custom-footer-render-id")
+            yield Static(f"render id: {self.render_id} ", classes="custom-footer-render-id")
 
     def show_render_finished(self) -> None:
         """Update footer text to show render-finished keybindings."""

--- a/tui/widget_helpers.py
+++ b/tui/widget_helpers.py
@@ -105,7 +105,7 @@ def display_success_message(tui, rendered_code_path: str):
         rendered_code_path: The path to the rendered code
     """
 
-    message = f"[#79FC96]✓ Rendering finished![/#79FC96] [#888888](enter to exit)[/#888888]\n[#888888]Generated code: {rendered_code_path}[/#888888] "
+    message = f"[#79FC96]✓ Rendering finished![/#79FC96] [#888888](press enter to exit)[/#888888]\n[#888888]Generated code: {rendered_code_path}[/#888888] "
 
     widget: Static = tui.query_one(f"#{TUIComponents.RENDER_STATUS_WIDGET.value}", Static)
     widget.update(message)


### PR DESCRIPTION
## Summary
- Added trailing space after render ID in the footer for better visual padding
- Clarified exit instruction from "(enter to exit)" to "(press enter to exit)" for better UX clarity

## Test plan
- [ ] Verify render ID in footer displays with proper spacing
- [ ] Verify success message shows "press enter to exit" after rendering completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)