### PR TITLE
Test script timeout argument

### DIFF
--- a/module_renderer.py
+++ b/module_renderer.py
@@ -176,6 +176,7 @@ class ModuleRenderer:
             verbose=self.args.verbose,
             run_state=self.run_state,
             event_bus=self.event_bus,
+            test_script_timeout=self.args.test_script_timeout,
         )
 
     def _render_module(

--- a/plain2code.py
+++ b/plain2code.py
@@ -47,8 +47,6 @@ from plain2code_utils import print_dry_run_output
 from system_config import system_config
 from tui.plain2code_tui import Plain2CodeTUI
 
-TEST_SCRIPT_EXECUTION_TIMEOUT = 120  # 120 seconds
-
 DEFAULT_TEMPLATE_DIRS = importlib.resources.files("standard_template_library")
 
 MAX_UNITTEST_FIX_ATTEMPTS = 20

--- a/plain2code_arguments.py
+++ b/plain2code_arguments.py
@@ -203,6 +203,13 @@ def create_parser():
     )
 
     parser.add_argument(
+        "--test-script-timeout",
+        type=int,
+        default=None,
+        help="Timeout for test scripts in seconds. If not provided, the default timeout of 120 seconds is used.",
+    )
+
+    parser.add_argument(
         "--api",
         type=str,
         nargs="?",

--- a/render_machine/actions/prepare_testing_environment.py
+++ b/render_machine/actions/prepare_testing_environment.py
@@ -21,6 +21,7 @@ class PrepareTestingEnvironment(BaseAction):
             [render_context.build_folder],
             render_context.verbose,
             "Testing Environment Preparation",
+            timeout=render_context.test_script_timeout,
         )
 
         render_context.conformance_tests_running_context.should_prepare_testing_environment = False

--- a/render_machine/actions/run_conformance_tests.py
+++ b/render_machine/actions/run_conformance_tests.py
@@ -43,7 +43,8 @@ class RunConformanceTests(BaseAction):
             [render_context.build_folder, conformance_tests_folder_name],
             render_context.verbose,
             "Conformance Tests",
-            render_context.conformance_tests_running_context.current_testing_frid,
+            frid=render_context.conformance_tests_running_context.current_testing_frid,
+            timeout=render_context.test_script_timeout,
         )
         render_context.script_execution_history.latest_conformance_test_output_path = conformance_tests_temp_file_path
         render_context.script_execution_history.should_update_script_outputs = True

--- a/render_machine/actions/run_unit_tests.py
+++ b/render_machine/actions/run_unit_tests.py
@@ -24,6 +24,7 @@ class RunUnitTests(BaseAction):
             [render_context.build_folder],
             render_context.verbose,
             "Unit Tests",
+            timeout=render_context.test_script_timeout,
         )
 
         render_context.script_execution_history.latest_unit_test_output_path = unittests_temp_file_path

--- a/render_machine/render_context.py
+++ b/render_machine/render_context.py
@@ -51,6 +51,7 @@ class RenderContext:
         verbose: bool,
         run_state: RunState,
         event_bus: EventBus,
+        test_script_timeout: Optional[int] = None,
     ):
         self.codeplain_api: CodeplainAPI = codeplain_api
         self.memory_manager = memory_manager
@@ -75,6 +76,7 @@ class RenderContext:
         self.event_bus = event_bus
         self.script_execution_history = ScriptExecutionHistory()
         self.starting_frid = None
+        self.test_script_timeout = test_script_timeout
 
         resources_list = []
         plain_spec.collect_linked_resources(plain_source_tree, resources_list, None, True)

--- a/render_machine/render_utils.py
+++ b/render_machine/render_utils.py
@@ -42,9 +42,15 @@ def print_inputs(render_context, existing_files_content, message):
 
 
 def execute_script(
-    script: str, scripts_args: list[str], verbose: bool, script_type: str, frid: Optional[str] = None
+    script: str,
+    scripts_args: list[str],
+    verbose: bool,
+    script_type: str,
+    frid: Optional[str] = None,
+    timeout: Optional[int] = None,
 ) -> tuple[int, str, Optional[str]]:
     temp_file_path = None
+    script_timeout = timeout if timeout is not None else SCRIPT_EXECUTION_TIMEOUT
     try:
         start_time = time.time()
         result = subprocess.run(
@@ -52,7 +58,7 @@ def execute_script(
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             text=True,
-            timeout=SCRIPT_EXECUTION_TIMEOUT,
+            timeout=script_timeout,
         )
         elapsed_time = time.time() - start_time
         # Log the info about the script execution
@@ -90,7 +96,7 @@ def execute_script(
         # Store timeout output in a temporary file
         if verbose:
             with tempfile.NamedTemporaryFile(mode="w+", delete=False, suffix=".script_timeout") as temp_file:
-                temp_file.write(f"{script_type} script {script} timed out after {SCRIPT_EXECUTION_TIMEOUT} seconds.")
+                temp_file.write(f"{script_type} script {script} timed out after {script_timeout} seconds.")
                 if e.stdout:
                     decoded_output = e.stdout.decode("utf-8") if isinstance(e.stdout, bytes) else e.stdout
                     temp_file.write(f"{script_type} script partial output before the timeout:\n{decoded_output}")
@@ -98,11 +104,11 @@ def execute_script(
                     temp_file.write(f"{script_type} script did not produce any output before the timeout.")
                 temp_file_path = temp_file.name
             console.warning(
-                f"The {script_type} script timed out after {SCRIPT_EXECUTION_TIMEOUT} seconds. {script_type} script output stored in: {temp_file_path}"
+                f"The {script_type} script timed out after {script_timeout} seconds. {script_type} script output stored in: {temp_file_path}"
             )
 
         return (
             TIMEOUT_ERROR_EXIT_CODE,
-            f"{script_type} script did not finish in {SCRIPT_EXECUTION_TIMEOUT} seconds.",
+            f"{script_type} script did not finish in {script_timeout} seconds.",
             temp_file_path,
         )


### PR DESCRIPTION
Adding an argument to the client to set the test script timeout manually. This is necessary for projects with longer compilation times.