### PR TITLE
"No linked resources found" sounded like an error.

### DIFF
--- a/plain2code_console.py
+++ b/plain2code_console.py
@@ -97,7 +97,7 @@ class Plain2CodeConsole(Console):
 
     def print_resources(self, resources_list, linked_resources):
         if len(resources_list) == 0:
-            self.input("No linked resources found.")
+            self.input("Linked resources: None")
             return
 
         self.input("Linked resources:")


### PR DESCRIPTION
"No linked resources found" sounded like an error. Changing the text to better communicate intent.

Note:

I wanted to also set this to DEBUG level. Unfortunately current implementation of log window is incorrect. If the logging level is set to INFO (which is normal situation), DEBUG messages are discarded and cannot be shown when the user clicks "DEBUG" in TUI.