### PR TITLE
Removing "color" from parser

### DIFF
--- a/docs/generate_cli.py
+++ b/docs/generate_cli.py
@@ -9,7 +9,7 @@ def main():
     from plain2code_arguments import create_parser
 
     # Get the parser and generate help text
-    parser = create_parser(color=False)  # Disable color for markdown output
+    parser = create_parser()  # Disable color for markdown output
     help_text = parser.format_help()
 
     # Create markdown

--- a/plain2code_arguments.py
+++ b/plain2code_arguments.py
@@ -1,6 +1,5 @@
 import argparse
 import os
-import sys
 from typing import Any
 
 from plain2code_console import console
@@ -162,14 +161,11 @@ def update_args_with_config(args, parser):
     return args
 
 
-def create_parser(color: bool = False):
+def create_parser():
     """Create the argument parser without parsing arguments."""
     parser_kwargs: dict[str, Any] = {
         "description": "Render plain code to target code.",
     }
-
-    if sys.version_info >= (3, 13):
-        parser_kwargs["color"] = color
 
     parser = argparse.ArgumentParser(**parser_kwargs)
 


### PR DESCRIPTION
Removing color argument in plain2code_arguments.py in create_parser function. 