### PR TITLE
Add hours and remove milliseconds from log entries

### DIFF
--- a/plain2code_logger.py
+++ b/plain2code_logger.py
@@ -27,11 +27,12 @@ class TuiLoggingHandler(logging.Handler):
 
     def emit(self, record):
         try:
-            offset_seconds = record.created - self.start_time
-            minutes = int(offset_seconds // 60)
-            seconds = int(offset_seconds % 60)
-            milliseconds = int((offset_seconds % 1) * 100)
-            timestamp = f"{minutes:02d}:{seconds:02d}:{milliseconds:02d}"
+            offset_seconds = int(record.created - self.start_time)
+            hours = offset_seconds // 3600
+            minutes = (offset_seconds % 3600) // 60
+            seconds = offset_seconds % 60
+            timestamp = f"{hours:02d}:{minutes:02d}:{seconds:02d}"
+
             event = LogMessageEmitted(
                 logger_name=record.name,
                 level=record.levelname,


### PR DESCRIPTION
This adds hours to the log entries' timestamps. It also removes the milliseconds which were broken anyway (2 digits where it should be 3).

<img width="1078" height="631" alt="image" src="https://github.com/user-attachments/assets/c7452e50-9166-49a2-9fde-2c841bdd0c92" />
