### PR TITLE
Fixing ExitWithError action

### DIFF
--- a/render_machine/actions/exit_with_error.py
+++ b/render_machine/actions/exit_with_error.py
@@ -3,6 +3,7 @@ from typing import Any
 from plain2code_console import console
 from render_machine.actions.base_action import BaseAction
 from render_machine.render_context import RenderContext
+from render_machine.render_types import RenderError
 
 
 class ExitWithError(BaseAction):
@@ -24,4 +25,9 @@ class ExitWithError(BaseAction):
         if render_context.run_state.render_id is not None:
             console.info(f"Render ID: {render_context.run_state.render_id}")
 
-        return self.SUCCESSFUL_OUTCOME, previous_action_payload
+        return (
+            self.SUCCESSFUL_OUTCOME,
+            RenderError.encode(
+                message=render_context.last_error_message or "Unknown error",
+            ).to_payload(),
+        )

--- a/render_machine/code_renderer.py
+++ b/render_machine/code_renderer.py
@@ -59,7 +59,6 @@ class CodeRenderer:
             previous_state = deepcopy(self.render_context.state)
             self.render_context.script_execution_history.should_update_script_outputs = False
             # Reset error message at start of each iteration to prevent stale data
-            self.render_context.last_error_message = None
 
             outcome, previous_action_payload = self.action_map[self.render_context.state].execute(
                 self.render_context, previous_action_payload

--- a/render_machine/code_renderer.py
+++ b/render_machine/code_renderer.py
@@ -58,7 +58,6 @@ class CodeRenderer:
             )
             previous_state = deepcopy(self.render_context.state)
             self.render_context.script_execution_history.should_update_script_outputs = False
-            # Reset error message at start of each iteration to prevent stale data
 
             outcome, previous_action_payload = self.action_map[self.render_context.state].execute(
                 self.render_context, previous_action_payload

--- a/render_machine/render_context.py
+++ b/render_machine/render_context.py
@@ -443,6 +443,7 @@ class RenderContext:
                 self.conformance_tests_running_context.conformance_tests_render_attempts
                 >= MAX_CONFORMANCE_TEST_RERENDER_ATTEMPTS
             ):
+                # TODO: Change the below error message
                 error_msg = f"We've already tried to fix the issue by recreating the conformance tests but tests still fail. Please fix the issues manually. FRID: {self.frid_context.frid}, Render ID: {self.run_state.render_id}"
                 self.dispatch_error(error_msg)
             else:

--- a/render_machine/render_context.py
+++ b/render_machine/render_context.py
@@ -443,8 +443,7 @@ class RenderContext:
                 self.conformance_tests_running_context.conformance_tests_render_attempts
                 >= MAX_CONFORMANCE_TEST_RERENDER_ATTEMPTS
             ):
-                # TODO: Change the below error message
-                error_msg = f"We've already tried to fix the issue by recreating the conformance tests but tests still fail. Please fix the issues manually. FRID: {self.frid_context.frid}, Render ID: {self.run_state.render_id}"
+                error_msg = f"The renderer was unable to produce an implementation that passes conformance tests for functionality '{self.frid_context.frid}' after many attempts. Please review and rewrite the specification. (Render ID: {self.run_state.render_id})"
                 self.dispatch_error(error_msg)
             else:
                 self.conformance_tests_running_context.regenerating_conformance_tests = True


### PR DESCRIPTION
This PR fixes the `Unexpected error format: dict` issue. This happens after 20 failed attempts to fix the conformance tests. The fix is to let the `ExitWithError` action return the `RenderError` object rather than `previous_action_payload`. 

Putting this PR in WIP stage since we also need to update the message. The message

```txt
We've already tried to fix the issue by recreating the conformance tests but tests still fail. Please fix the issues manually. FRID: {self.frid_context.frid}, Render ID: {self.run_state.render_id}
```

doesnt feel right. 
