### PR TITLE
Add module_name to render_func_id related API calls

### DIFF
--- a/codeplain_REST_api.py
+++ b/codeplain_REST_api.py
@@ -262,12 +262,15 @@ class CodeplainAPI:
 
         return self.post_request(endpoint_url, headers, payload, run_state)
 
-    def refactor_source_files_if_needed(self, frid, files_to_check, existing_files_content, run_state: RunState):
+    def refactor_source_files_if_needed(
+        self, frid, module_name: str, files_to_check, existing_files_content, run_state: RunState
+    ):
         endpoint_url = f"{self.api_url}/refactor_source_files_if_needed"
         headers = {"X-API-Key": self.api_key, "Content-Type": "application/json"}
 
         payload = {
             "frid": frid,
+            "module_name": module_name,
             "files_to_check": list(files_to_check),
             "existing_files_content": existing_files_content,
         }
@@ -312,6 +315,7 @@ class CodeplainAPI:
     def generate_folder_name_from_functional_requirement(
         self,
         frid,
+        module_name: str,
         functional_requirement,
         existing_folder_names,
         run_state: RunState,
@@ -321,6 +325,7 @@ class CodeplainAPI:
 
         payload = {
             "frid": frid,
+            "module_name": module_name,
             "functional_requirement": functional_requirement,
             "existing_folder_names": existing_folder_names,
         }
@@ -454,22 +459,24 @@ class CodeplainAPI:
 
         return self.post_request(endpoint_url, headers, payload, run_state)
 
-    def finish_functional_requirement(self, frid, run_state: RunState):
+    def finish_functional_requirement(self, frid, module_name: str, run_state: RunState):
         endpoint_url = f"{self.api_url}/finish_functional_requirement"
         headers = {"X-API-Key": self.api_key, "Content-Type": "application/json"}
 
         payload = {
             "frid": frid,
+            "module_name": module_name,
         }
 
         return self.post_request(endpoint_url, headers, payload, run_state)
 
-    def fail_functional_requirement(self, frid, run_state: RunState):
+    def fail_functional_requirement(self, frid, module_name: str, run_state: RunState):
         endpoint_url = f"{self.api_url}/fail_functional_requirement"
         headers = {"X-API-Key": self.api_key, "Content-Type": "application/json"}
 
         payload = {
             "frid": frid,
+            "module_name": module_name,
         }
 
         return self.post_request(endpoint_url, headers, payload, run_state)

--- a/render_machine/actions/exit_with_error.py
+++ b/render_machine/actions/exit_with_error.py
@@ -13,6 +13,7 @@ class ExitWithError(BaseAction):
 
         render_context.codeplain_api.fail_functional_requirement(
             render_context.frid_context.frid,
+            module_name=render_context.module_name,
             run_state=render_context.run_state,
         )
 

--- a/render_machine/actions/finish_functional_requirement.py
+++ b/render_machine/actions/finish_functional_requirement.py
@@ -12,6 +12,7 @@ class FinishFunctionalRequirement(CommitImplementationCodeChanges):
 
         render_context.codeplain_api.finish_functional_requirement(
             render_context.frid_context.frid,
+            module_name=render_context.module_name,
             run_state=render_context.run_state,
         )
 

--- a/render_machine/actions/refactor_code.py
+++ b/render_machine/actions/refactor_code.py
@@ -31,6 +31,7 @@ class RefactorCode(BaseAction):
         ):
             response_files = render_context.codeplain_api.refactor_source_files_if_needed(
                 frid=render_context.frid_context.frid,
+                module_name=render_context.module_name,
                 files_to_check=render_context.frid_context.changed_files,
                 existing_files_content=existing_files_content,
                 run_state=render_context.run_state,

--- a/render_machine/actions/render_conformance_tests.py
+++ b/render_machine/actions/render_conformance_tests.py
@@ -38,6 +38,7 @@ class RenderConformanceTests(BaseAction):
             ):
                 fr_subfolder_name = render_context.codeplain_api.generate_folder_name_from_functional_requirement(
                     frid=render_context.conformance_tests_running_context.current_testing_frid,
+                    module_name=render_context.conformance_tests_running_context.current_testing_module_name,
                     functional_requirement=render_context.conformance_tests_running_context.current_testing_frid_specifications[
                         plain_spec.FUNCTIONAL_REQUIREMENTS
                     ][


### PR DESCRIPTION
`module_name` was added to all render related API endpoints. This PR extends the client to send appropriate data.