### PR TITLE
Improve path resolution

### DIFF
--- a/docs/plain2code_cli.md
+++ b/docs/plain2code_cli.md
@@ -1,22 +1,41 @@
 # Plain2Code CLI Reference
 
 ```text
-usage: generate_cli.py [-h] [--verbose] [--base-folder BASE_FOLDER] [--build-folder BUILD_FOLDER] [--log-to-file | --no-log-to-file]
-                       [--log-file-name LOG_FILE_NAME] [--config-name CONFIG_NAME] [--render-range RENDER_RANGE | --render-from RENDER_FROM]
-                       [--force-render] [--unittests-script UNITTESTS_SCRIPT] [--conformance-tests-folder CONFORMANCE_TESTS_FOLDER]
-                       [--conformance-tests-script CONFORMANCE_TESTS_SCRIPT] [--prepare-environment-script PREPARE_ENVIRONMENT_SCRIPT]
-                       [--test-script-timeout TEST_SCRIPT_TIMEOUT] [--api [API]] [--api-key API_KEY] [--full-plain] [--dry-run]
-                       [--replay-with REPLAY_WITH] [--template-dir TEMPLATE_DIR] [--copy-build] [--build-dest BUILD_DEST]
-                       [--copy-conformance-tests] [--conformance-tests-dest CONFORMANCE_TESTS_DEST] [--render-machine-graph]
-                       [--logging-config-path LOGGING_CONFIG_PATH] [--headless]
+usage: generate_cli.py [-h] [--verbose] [--base-folder BASE_FOLDER]
+                       [--build-folder BUILD_FOLDER]
+                       [--log-to-file | --no-log-to-file]
+                       [--log-file-name LOG_FILE_NAME]
+                       [--config-name CONFIG_NAME]
+                       [--render-range RENDER_RANGE |
+                       --render-from RENDER_FROM] [--force-render]
+                       [--unittests-script UNITTESTS_SCRIPT]
+                       [--conformance-tests-folder CONFORMANCE_TESTS_FOLDER]
+                       [--conformance-tests-script CONFORMANCE_TESTS_SCRIPT]
+                       [--prepare-environment-script PREPARE_ENVIRONMENT_SCRIPT]
+                       [--test-script-timeout TEST_SCRIPT_TIMEOUT]
+                       [--api [API]] [--api-key API_KEY] [--full-plain]
+                       [--dry-run] [--replay-with REPLAY_WITH]
+                       [--template-dir TEMPLATE_DIR] [--copy-build]
+                       [--build-dest BUILD_DEST] [--copy-conformance-tests]
+                       [--conformance-tests-dest CONFORMANCE_TESTS_DEST]
+                       [--render-machine-graph]
+                       [--logging-config-path LOGGING_CONFIG_PATH]
+                       [--headless]
                        filename
 
-Render plain code to target code.
+Render plain code to target code. Path arguments resolve based on where they
+were written: values given on the command line are resolved against the
+current working directory, values read from config.yaml are resolved against
+the config file's directory, and defaults are resolved against the directory
+containing the plain file. Absolute paths (and paths starting with '~') are
+used as-is.
 
 positional arguments:
-  filename              Path to the plain file to render. The directory containing this file has highest precedence for template loading, so
-                        you can place custom templates here to override the defaults. See --template-dir for more details about template
-                        loading.
+  filename              Path to the plain file to render. The directory
+                        containing this file has highest precedence for
+                        template loading, so you can place custom templates
+                        here to override the defaults. See --template-dir for
+                        more details about template loading.
 
 options:
   -h, --help            show this help message and exit
@@ -26,60 +45,89 @@ options:
   --build-folder BUILD_FOLDER
                         Folder for build files
   --log-to-file, --no-log-to-file
-                        Enable logging to a file. Defaults to True. Set to False to disable.
+                        Enable logging to a file. Defaults to True. Set to
+                        False to disable.
   --log-file-name LOG_FILE_NAME
-                        Name of the log file. Defaults to 'codeplain.log'.Always resolved relative to the plain file directory.If file on
-                        this path already exists, the already existing log file will be overwritten by the current logs.
+                        Name of the log file. Defaults to 'codeplain.log'. If
+                        a file already exists at the resolved path, it will be
+                        overwritten by the current logs.
   --render-range RENDER_RANGE
-                        Specify a range of functionalities to render (e.g. `1` , `2`, `3`). Use comma to separate start and end IDs. If only
-                        one functionality ID is provided, only that functionality is rendered. Range is inclusive of both start and end IDs.
+                        Specify a range of functionalities to render (e.g. `1`
+                        , `2`, `3`). Use comma to separate start and end IDs.
+                        If only one functionality ID is provided, only that
+                        functionality is rendered. Range is inclusive of both
+                        start and end IDs.
   --render-from RENDER_FROM
-                        Continue generation starting from this specific functionality (e.g. `2`). The functionality with this ID will be
-                        included in the output. The functionality ID must match one of the functionalities in your plain file.
+                        Continue generation starting from this specific
+                        functionality (e.g. `2`). The functionality with this
+                        ID will be included in the output. The functionality
+                        ID must match one of the functionalities in your plain
+                        file.
   --force-render        Force re-render of all the required modules.
   --unittests-script UNITTESTS_SCRIPT
-                        Shell script to run unit tests on generated code. Receives the build folder path as its first argument (default:
-                        'plain_modules').
+                        Shell script to run unit tests on generated code.
+                        Receives the build folder path as its first argument
+                        (default: 'plain_modules').
   --conformance-tests-folder CONFORMANCE_TESTS_FOLDER
                         Folder for conformance test files
   --conformance-tests-script CONFORMANCE_TESTS_SCRIPT
-                        Path to conformance tests shell script. Every conformance test script should accept two arguments: 1) Path to a
-                        folder (e.g. `plain_modules/module_name`) containing generated source code, 2) Path to a subfolder of the conformance
-                        tests folder (e.g. `conformance_tests/subfoldername`) containing test files.
+                        Path to conformance tests shell script. Every
+                        conformance test script should accept two arguments:
+                        1) Path to a folder (e.g. `plain_modules/module_name`)
+                        containing generated source code, 2) Path to a
+                        subfolder of the conformance tests folder (e.g.
+                        `conformance_tests/subfoldername`) containing test
+                        files.
   --prepare-environment-script PREPARE_ENVIRONMENT_SCRIPT
-                        Path to a shell script that prepares the testing environment. The script should accept the source code folder path as
-                        its first argument.
+                        Path to a shell script that prepares the testing
+                        environment. The script should accept the source code
+                        folder path as its first argument.
   --test-script-timeout TEST_SCRIPT_TIMEOUT
-                        Timeout for test scripts in seconds. If not provided, the default timeout of 120 seconds is used.
-  --api [API]           Alternative base URL for the API. Default: `https://api.codeplain.ai`
-  --api-key API_KEY     API key used to access the API. If not provided, the `CODEPLAIN_API_KEY` environment variable is used.
-  --full-plain          Full preview ***plain specification before code generation.Use when you want to preview context of all ***plain
-                        primitives that are going to be included in order to render the given module.
-  --dry-run             Dry run preview of the code generation (without actually making any changes).
+                        Timeout for test scripts in seconds. If not provided,
+                        the default timeout of 120 seconds is used.
+  --api [API]           Alternative base URL for the API. Default:
+                        `https://api.codeplain.ai`
+  --api-key API_KEY     API key used to access the API. If not provided, the
+                        `CODEPLAIN_API_KEY` environment variable is used.
+  --full-plain          Full preview ***plain specification before code
+                        generation.Use when you want to preview context of all
+                        ***plain primitives that are going to be included in
+                        order to render the given module.
+  --dry-run             Dry run preview of the code generation (without
+                        actually making any changes).
   --replay-with REPLAY_WITH
   --template-dir TEMPLATE_DIR
-                        Path to a custom template directory. Templates are searched in the following order: 1) Directory containing the plain
-                        file, 2) Custom template directory (if provided through this argument), 3) Built-in standard_template_library
-                        directory
-  --copy-build          If set, copy the rendered contents of code in `--base-folder` folder to `--build-dest` folder after successful
-                        rendering.
+                        Path to a custom template directory. Templates are
+                        searched in the following order: 1) Directory
+                        containing the plain file, 2) Custom template
+                        directory (if provided through this argument), 3)
+                        Built-in standard_template_library directory
+  --copy-build          If set, copy the rendered contents of code in `--base-
+                        folder` folder to `--build-dest` folder after
+                        successful rendering.
   --build-dest BUILD_DEST
-                        Target folder to copy rendered contents of code to (used only if --copy-build is set).
+                        Target folder to copy rendered contents of code to
+                        (used only if --copy-build is set).
   --copy-conformance-tests
-                        If set, copy the conformance tests of code in `--conformance-tests-folder` folder to `--conformance-tests-dest`
-                        folder successful rendering. Requires --conformance-tests-script.
+                        If set, copy the conformance tests of code in
+                        `--conformance-tests-folder` folder to `--conformance-
+                        tests-dest` folder successful rendering. Requires
+                        --conformance-tests-script.
   --conformance-tests-dest CONFORMANCE_TESTS_DEST
-                        Target folder to copy conformance tests of code to (used only if --copy-conformance-tests is set).
+                        Target folder to copy conformance tests of code to
+                        (used only if --copy-conformance-tests is set).
   --render-machine-graph
                         If set, render the state machine graph.
   --logging-config-path LOGGING_CONFIG_PATH
                         Path to the logging configuration file.
-  --headless            Run in headless mode: no TUI, no terminal output except a single render-started message. All logs are written to the
-                        log file.
+  --headless            Run in headless mode: no TUI, no terminal output
+                        except a single render-started message. All logs are
+                        written to the log file.
 
 configuration:
   --config-name CONFIG_NAME
-                        Name of the config file to look for. Looked up in the plain file directory and the current working directory.
-                        Defaults to config.yaml.
+                        Name of the config file to look for. Looked up in the
+                        plain file directory and the current working
+                        directory. Defaults to config.yaml.
 
 ```

--- a/file_utils.py
+++ b/file_utils.py
@@ -293,7 +293,7 @@ def get_template_directories(plain_file_path, custom_template_dir=None, default_
     3. Default template directory - for standard/fallback templates
     """
     template_dirs = [
-        os.path.dirname(plain_file_path),  # Highest precedence - directory containing plain file
+        os.path.dirname(os.path.abspath(plain_file_path)),  # Highest precedence - directory containing plain file
     ]
 
     if custom_template_dir:

--- a/module_renderer.py
+++ b/module_renderer.py
@@ -158,13 +158,14 @@ class ModuleRenderer:
                     module.wipe_module()
 
         self.loaded_modules = list[PlainModule]()
+
         _, rendering_failed = self._render_module(self.plain_module, self.render_range, True)
+
         if not rendering_failed:
-            # Get the last module that completed rendering
             if self.args.copy_build:
                 rendered_code_path = f"{self.args.build_dest}/"
             else:
-                rendered_code_path = f"{os.path.join(self.args.build_folder, self.plain_module.module_name)}/"
+                rendered_code_path = self.args.build_folder
 
             self.run_state.set_render_generated_code_path(rendered_code_path)
             self.event_bus.publish(RenderCompleted(rendered_code_path=rendered_code_path))

--- a/path_resolution.py
+++ b/path_resolution.py
@@ -1,0 +1,64 @@
+"""Path resolution for CLI / config / default path arguments.
+
+The rule, in one sentence: the resolution base for a relative path is determined
+by *where the value was written*, not by which option key it sets.
+
+- Values supplied on the command line resolve against the current working
+  directory (so they match what shell tab completion just produced).
+- Values read from ``config.yaml`` resolve against the directory containing
+  that config file.
+- Values left at their default (not supplied anywhere) resolve against the
+  directory containing the spec file.
+
+Paths are expanded for ``~`` and returned as absolute paths. Canonicalization
+(symlink resolution) is left to the caller, to be done just before I/O that
+needs it (writing output, executing scripts) so we don't accidentally
+dereference links the user wanted preserved.
+"""
+
+import os
+from typing import Literal, Optional
+
+PathSource = Literal["cli", "config", "default"]
+
+
+def resolve_path(
+    value: str,
+    source: PathSource,
+    *,
+    cwd: str,
+    config_dir: Optional[str] = None,
+    spec_dir: str,
+) -> str:
+    """Resolve *value* to an absolute path using the base anchor for *source*.
+
+    Args:
+        value: The path string as written by the user. May be absolute, relative,
+            or contain a leading ``~``.
+        source: Where the value came from -- ``"cli"``, ``"config"``, or
+            ``"default"``.
+        cwd: Base directory for ``"cli"`` values.
+        config_dir: Base directory for ``"config"`` values. Must be provided
+            whenever ``source == "config"``.
+        spec_dir: Base directory for ``"default"`` values.
+
+    Returns:
+        Absolute path with ``~`` expanded. Symlinks are not resolved.
+    """
+    expanded = os.path.expanduser(value)
+
+    if os.path.isabs(expanded):
+        return os.path.normpath(expanded)
+
+    if source == "cli":
+        base = cwd
+    elif source == "config":
+        if config_dir is None:
+            raise ValueError("config_dir must be provided when source == 'config'")
+        base = config_dir
+    elif source == "default":
+        base = spec_dir
+    else:
+        raise ValueError(f"Unknown path source: {source!r}")
+
+    return os.path.normpath(os.path.join(base, expanded))

--- a/plain2code.py
+++ b/plain2code.py
@@ -46,7 +46,6 @@ from plain2code_logger import (
     IndentedFormatter,
     LoggingHandler,
     dump_crash_logs,
-    get_log_file_path,
 )
 from plain2code_state import RunState
 from plain2code_telemetry import capture_crash, initialize_telemetry
@@ -85,8 +84,7 @@ def setup_logging(
     event_bus: EventBus,
     run_state: RunState,
     log_to_file: bool,
-    log_file_name: str,
-    plain_file_path: Optional[str],
+    log_file_path: str,
     headless: bool = False,
 ):
     default_level = logging.DEBUG if args.verbose else logging.INFO
@@ -97,10 +95,9 @@ def setup_logging(
     logging.getLogger("transitions").setLevel(logging.ERROR)
     logging.getLogger("transitions.extensions.diagrams").setLevel(logging.ERROR)
 
-    log_file_path = get_log_file_path(plain_file_path, log_file_name)
-
     # Try to load logging configuration from YAML file (takes precedence over --verbose)
     config_loaded = False
+
     if args.logging_config_path and os.path.exists(args.logging_config_path):
         try:
             with open(args.logging_config_path, "r") as f:
@@ -123,7 +120,7 @@ def setup_logging(
         handler.setFormatter(formatter)
         root_logger.addHandler(handler)
 
-    if log_to_file and log_file_path:
+    if log_to_file:
         try:
             file_handler = logging.FileHandler(log_file_path, mode="w", encoding="utf-8")
             file_handler.setFormatter(file_formatter)
@@ -351,7 +348,7 @@ def main():  # noqa: C901
     # Parse the plain file (and its required modules) once; reused by dry-run and rendering.
     try:
         plain_module = plain_modules.PlainModule(
-            args.filename,
+            os.path.basename(args.filename),
             args.build_folder,
             args.conformance_tests_folder,
             template_dirs,
@@ -378,9 +375,7 @@ def main():  # noqa: C901
         # Suppress Rich console output.
         console.quiet = True
 
-    default_log_level = setup_logging(
-        args, event_bus, run_state, args.log_to_file, args.log_file_name, args.filename, args.headless
-    )
+    default_log_level = setup_logging(args, event_bus, run_state, args.log_to_file, args.log_file_name, args.headless)
 
     initialize_telemetry()
 

--- a/plain2code_arguments.py
+++ b/plain2code_arguments.py
@@ -1,10 +1,16 @@
 import argparse
 import os
-from typing import Any
+from typing import Optional, Sequence
 
+from path_resolution import resolve_path
 from plain2code_console import console
 from plain2code_exceptions import AmbiguousConfigFileError
 from plain2code_read_config import get_args_from_config
+
+# Attribute on the parsed Namespace mapping each argument dest to its source:
+# "cli" (explicit on the command line), "config" (from config.yaml), or
+# "default" (neither -- the argparse default was used).
+ARGUMENT_SOURCES = "argument_sources"
 
 CODEPLAIN_API_KEY = os.getenv("CODEPLAIN_API_KEY")
 
@@ -20,36 +26,48 @@ DEFAULT_LOG_FILE_NAME = "codeplain.log"
 PREPARE_ENVIRONMENT_SCRIPT_NAME = "prepare_environment_script"
 
 
-def process_test_script_path(script_arg_name, config):
-    """Resolve script paths in config."""
-    config_file = config.config_name
-    script_input_path = getattr(config, script_arg_name, None)
-    if script_input_path is None:
-        return config
+def _resolve_path_arg(
+    arg_name: str,
+    args,
+    cwd: str,
+    config_dir: Optional[str],
+    spec_dir: str,
+) -> Optional[str]:
+    """Resolve a path-valued argument on ``args`` in-place using its recorded source.
 
-    # Check if the script path is absolute and keep the same path
-    if isinstance(script_input_path, str) and script_input_path.startswith("/"):
-        if not os.path.exists(script_input_path):
-            raise FileNotFoundError(
-                f"File not found: Path for {script_arg_name} not found: {script_input_path}. Set it to the absolute path or relative to the config file.\n"
-            )
-        return config
+    Returns the resolved absolute path, or ``None`` if the argument is unset.
+    """
+    original_value = getattr(args, arg_name, None)
+    if original_value is None:
+        return None
 
-    # Otherwise the script path is relative
-    # First look for it in the config file directory, then the renderer directory
-    config_dir = os.path.dirname(os.path.abspath(config_file))
-    config_relative_path = os.path.join(config_dir, script_input_path)
-    renderer_dir = os.path.dirname(os.path.abspath(__file__))
-    renderer_relative_path = os.path.join(renderer_dir, script_input_path)
-    if os.path.exists(config_relative_path):
-        setattr(config, script_arg_name, config_relative_path)
-    elif os.path.exists(renderer_relative_path):
-        setattr(config, script_arg_name, renderer_relative_path)
-    else:
+    source = getattr(args, ARGUMENT_SOURCES, {}).get(arg_name, "default")
+    resolved = resolve_path(original_value, source, cwd=cwd, config_dir=config_dir, spec_dir=spec_dir)
+    setattr(args, arg_name, resolved)
+    return resolved
+
+
+def _resolve_script_path(
+    script_arg_name: str,
+    args,
+    cwd: str,
+    config_dir: Optional[str],
+    spec_dir: str,
+) -> None:
+    """Resolve a script-path argument and verify the script exists on disk.
+
+    Scripts are expected to exist at parse time because we are about to execute
+    them; missing directories, by contrast, are created on demand.
+    """
+    original_value = getattr(args, script_arg_name, None)
+    resolved = _resolve_path_arg(script_arg_name, args, cwd, config_dir, spec_dir)
+    if resolved is None:
+        return
+
+    if not os.path.exists(resolved):
         raise FileNotFoundError(
-            f"File not found: Path for {script_arg_name} not found: {script_input_path}. Set it to the absolute path or relative to the config file.\n"
+            f"File not found: Path for {script_arg_name} not found: {original_value} (resolved to {resolved})."
         )
-    return config
 
 
 def non_empty_string(s):
@@ -119,93 +137,133 @@ def resolve_config_file(config_name: str, plain_file_path: str):
     return None
 
 
-def update_args_with_config(args, parser):
+def _detect_cli_provided_keys(command_line: Optional[Sequence[str]] = None) -> set[str]:
+    """Return the set of argument dests that were explicitly provided on the command line.
+
+    Uses a second parser with every default replaced by ``argparse.SUPPRESS``, so
+    any dest that ends up on the resulting namespace must have come from the
+    command line.
+    """
+    tracker = create_parser()
+    for action in tracker._actions:
+        action.default = argparse.SUPPRESS
+    tracked_ns, _ = tracker.parse_known_args(command_line)
+    return set(vars(tracked_ns).keys())
+
+
+def update_args_with_config(args, parser, cli_provided: set[str]):
+    """Merge config.yaml values into ``args`` and record the source of each value.
+
+    CLI-supplied values always win. Anything the CLI did not supply is taken
+    from config.yaml if present, else left at its argparse default. The mapping
+    from dest to source ("cli" / "config" / "default") is attached to ``args``
+    as ``ARGUMENT_SOURCES`` so downstream code can resolve paths against the right
+    base directory.
+    """
+    action_dests = {action.dest for action in parser._actions}
+    sources: dict[str, str] = {dest: ("cli" if dest in cli_provided else "default") for dest in action_dests}
+
     try:
         resolved_config = resolve_config_file(args.config_name, args.filename)
 
         if resolved_config is None:
             console.info(f"No config file '{args.config_name}' found. Proceeding without one.")
+            setattr(args, ARGUMENT_SOURCES, sources)
             return args
 
         args.config_name = resolved_config
         config_args = get_args_from_config(resolved_config, parser)
 
-        # Get all action types from the parser
-        action_types = {action.dest: action for action in parser._actions}
-
-        # Update args with config values, but command line args take precedence
         for key, value in vars(config_args).items():
-            # Skip if the argument was provided on command line
-            if key in vars(args):
-                arg_action = action_types.get(key)
-                if arg_action and isinstance(arg_action, argparse._StoreAction):
-                    # For regular arguments, only skip if explicitly provided
-                    if getattr(args, key) is not None and (arg_action.default is None or value == arg_action.default):
-                        continue
-                elif arg_action and isinstance(arg_action, argparse._StoreTrueAction):
-                    # For boolean flags, skip if True (explicitly set)
-                    if getattr(args, key):
-                        continue
-
-            # Set the value from config
-            if key in action_types:
-                setattr(args, key, value)
-            else:
+            if key not in action_dests:
                 parser.error(f"Invalid argument: {key}")
+
+            # CLI takes precedence over config.
+            if key in cli_provided:
+                continue
+
+            setattr(args, key, value)
+            sources[key] = "config"
 
     except AmbiguousConfigFileError as e:
         parser.error(str(e))
     except Exception as e:
         parser.error(f"Error reading config file: {str(e)}")
 
+    setattr(args, ARGUMENT_SOURCES, sources)
     return args
+
+
+def _add_arg(parser, *args, path=False, **kwargs):
+    """Add an argument; tag as path-valued when ``path=True`` so ``parse_arguments`` resolves it."""
+    action = parser.add_argument(*args, **kwargs)
+    if path:
+        action._is_path = True
 
 
 def create_parser():
     """Create the argument parser without parsing arguments."""
-    parser_kwargs: dict[str, Any] = {
-        "description": "Render plain code to target code.",
-    }
+    parser = argparse.ArgumentParser(
+        description=(
+            "Render plain code to target code. "
+            "Path arguments resolve based on where they were written: "
+            "values given on the command line are resolved against the current working "
+            "directory, values read from config.yaml are resolved against the config "
+            "file's directory, and defaults are resolved against the directory containing "
+            "the plain file. Absolute paths (and paths starting with '~') are used as-is."
+        ),
+    )
 
-    parser = argparse.ArgumentParser(**parser_kwargs)
-
-    parser.add_argument(
+    _add_arg(
+        parser,
         "filename",
         type=str,
         nargs="?",
         help="Path to the plain file to render. The directory containing this file has highest precedence for template loading, "
         "so you can place custom templates here to override the defaults. See --template-dir for more details about template loading.",
     )
-    parser.add_argument(
+
+    _add_arg(
+        parser,
         "--verbose",
         "-v",
         action="store_true",
         default=False,
         help="Set default log level to DEBUG for TUI and file logs",
     )
-    parser.add_argument("--base-folder", type=str, help="Base folder for the build files")
-    parser.add_argument(
-        "--build-folder", type=non_empty_string, default=DEFAULT_BUILD_FOLDER, help="Folder for build files"
+
+    _add_arg(parser, "--base-folder", type=str, help="Base folder for the build files", path=True)
+
+    _add_arg(
+        parser,
+        "--build-folder",
+        type=non_empty_string,
+        default=DEFAULT_BUILD_FOLDER,
+        help="Folder for build files",
+        path=True,
     )
 
-    parser.add_argument(
+    _add_arg(
+        parser,
         "--log-to-file",
         action=argparse.BooleanOptionalAction,
         default=True,
         help="Enable logging to a file. Defaults to True. Set to False to disable.",
     )
-    parser.add_argument(
+    _add_arg(
+        parser,
         "--log-file-name",
         type=str,
         default=DEFAULT_LOG_FILE_NAME,
-        help=f"Name of the log file. Defaults to '{DEFAULT_LOG_FILE_NAME}'."
-        "Always resolved relative to the plain file directory."
-        "If file on this path already exists, the already existing log file will be overwritten by the current logs.",
+        help=f"Name of the log file. Defaults to '{DEFAULT_LOG_FILE_NAME}'. "
+        "If a file already exists at the resolved path, it will be overwritten by the current logs.",
+        path=True,
     )
 
     # Add config file arguments
     config_group = parser.add_argument_group("configuration")
-    config_group.add_argument(
+    _add_arg(
+        config_group,
         "--config-name",
         type=non_empty_string,
         default="config.yaml",
@@ -213,39 +271,46 @@ def create_parser():
     )
 
     render_range_group = parser.add_mutually_exclusive_group()
-    render_range_group.add_argument(
+    _add_arg(
+        render_range_group,
         "--render-range",
         type=frid_range_string,
         help="Specify a range of functionalities to render (e.g. `1` , `2`, `3`). "
         "Use comma to separate start and end IDs. If only one functionality ID is provided, only that functionality is rendered. "
         "Range is inclusive of both start and end IDs.",
     )
-    render_range_group.add_argument(
+    _add_arg(
+        render_range_group,
         "--render-from",
         type=frid_string,
         help="Continue generation starting from this specific functionality (e.g. `2`). "
         "The functionality with this ID will be included in the output. The functionality ID must match one of the functionalities in your plain file.",
     )
 
-    parser.add_argument(
+    _add_arg(
+        parser,
         "--force-render",
         action="store_true",
         default=False,
         help="Force re-render of all the required modules.",
     )
 
-    parser.add_argument(
+    _add_arg(
+        parser,
         "--unittests-script",
         type=str,
         help="Shell script to run unit tests on generated code. Receives the build folder path as its first argument (default: 'plain_modules').",
     )
-    parser.add_argument(
+    _add_arg(
+        parser,
         "--conformance-tests-folder",
         type=non_empty_string,
         default=DEFAULT_CONFORMANCE_TESTS_FOLDER,
         help="Folder for conformance test files",
+        path=True,
     )
-    parser.add_argument(
+    _add_arg(
+        parser,
         "--conformance-tests-script",
         type=str,
         help="Path to conformance tests shell script. Every conformance test script should accept two arguments: "
@@ -253,51 +318,59 @@ def create_parser():
         "2) Path to a subfolder of the conformance tests folder (e.g. `conformance_tests/subfoldername`) containing test files.",
     )
 
-    parser.add_argument(
+    _add_arg(
+        parser,
         "--prepare-environment-script",
         type=str,
         help="Path to a shell script that prepares the testing environment. The script should accept the source code folder path as its first argument.",
     )
 
-    parser.add_argument(
+    _add_arg(
+        parser,
         "--test-script-timeout",
         type=int,
         default=None,
         help="Timeout for test scripts in seconds. If not provided, the default timeout of 120 seconds is used.",
     )
 
-    parser.add_argument(
+    _add_arg(
+        parser,
         "--api",
         type=str,
         nargs="?",
         const="https://api.codeplain.ai",
         help="Alternative base URL for the API. Default: `https://api.codeplain.ai`",
     )
-    parser.add_argument(
+    _add_arg(
+        parser,
         "--api-key",
         type=str,
         default=CODEPLAIN_API_KEY,
         help="API key used to access the API. If not provided, the `CODEPLAIN_API_KEY` environment variable is used.",
     )
-    parser.add_argument(
+    _add_arg(
+        parser,
         "--full-plain",
         action="store_true",
-        help="Full preview ***plain specification before code generation."
+        help="Full preview ***plain specification before code generation. "
         "Use when you want to preview context of all ***plain primitives that are going to be included in order to render the given module.",
     )
-    parser.add_argument(
+    _add_arg(
+        parser,
         "--dry-run",
         action="store_true",
         help="Dry run preview of the code generation (without actually making any changes).",
     )
-    parser.add_argument(
+    _add_arg(
+        parser,
         "--replay-with",
         type=str,
         default=None,
         help="",
     )
 
-    parser.add_argument(
+    _add_arg(
+        parser,
         "--template-dir",
         type=str,
         default=None,
@@ -305,47 +378,58 @@ def create_parser():
         "1) Directory containing the plain file, "
         "2) Custom template directory (if provided through this argument), "
         "3) Built-in standard_template_library directory",
+        path=True,
     )
-    parser.add_argument(
+    _add_arg(
+        parser,
         "--copy-build",
         action="store_true",
         default=True,
         help="If set, copy the rendered contents of code in `--base-folder` folder to `--build-dest` folder after successful rendering.",
     )
-    parser.add_argument(
+    _add_arg(
+        parser,
         "--build-dest",
         type=non_empty_string,
         default=DEFAULT_BUILD_DEST,
         help="Target folder to copy rendered contents of code to (used only if --copy-build is set).",
+        path=True,
     )
-    parser.add_argument(
+    _add_arg(
+        parser,
         "--copy-conformance-tests",
         action="store_true",
         default=False,
         help="If set, copy the conformance tests of code in `--conformance-tests-folder` folder to `--conformance-tests-dest` folder successful rendering. Requires --conformance-tests-script.",
     )
-    parser.add_argument(
+    _add_arg(
+        parser,
         "--conformance-tests-dest",
         type=non_empty_string,
         default=DEFAULT_CONFORMANCE_TESTS_DEST,
         help="Target folder to copy conformance tests of code to (used only if --copy-conformance-tests is set).",
+        path=True,
     )
 
-    parser.add_argument(
+    _add_arg(
+        parser,
         "--render-machine-graph",
         action="store_true",
         default=False,
         help="If set, render the state machine graph.",
     )
 
-    parser.add_argument(
+    _add_arg(
+        parser,
         "--logging-config-path",
         type=str,
         default="logging_config.yaml",
         help="Path to the logging configuration file.",
+        path=True,
     )
 
-    parser.add_argument(
+    _add_arg(
+        parser,
         "--headless",
         action="store_true",
         default=False,
@@ -371,18 +455,38 @@ def create_parser():
     return parser
 
 
-def parse_arguments():
+def parse_arguments(command_line: Optional[Sequence[str]] = None):
     parser = create_parser()
 
-    args = parser.parse_args()
+    args = parser.parse_args(command_line)
+    cli_provided = _detect_cli_provided_keys(command_line)
+
+    if args.version:
+        if args.dry_run or args.full_plain:
+            parser.error("--version cannot be used with --dry-run or --full-plain")
+        return args
+
+    if args.status:
+        if args.dry_run or args.full_plain:
+            parser.error("--status cannot be used with --dry-run or --full-plain")
+        return args
 
     # Validate filename is provided when needed
-    if not args.status and not args.version and not args.filename:
+    if not args.version and not args.status and not args.filename:
         parser.error("the following arguments are required: filename")
 
-    # Only process config if filename is provided (not needed for --status)
-    if args.filename:
-        args = update_args_with_config(args, parser)
+    args = update_args_with_config(args, parser, cli_provided)
+
+    cwd = os.getcwd()
+
+    spec_dir = os.path.dirname(os.path.abspath(args.filename))
+    # args.config_name is the resolved absolute path when a config file was found,
+    # otherwise it is still just the lookup name (e.g. "config.yaml").
+    config_dir = os.path.dirname(args.config_name) if os.path.isabs(args.config_name) else None
+
+    for action in parser._actions:
+        if getattr(action, "_is_path", False):
+            _resolve_path_arg(action.dest, args, cwd, config_dir, spec_dir)
 
     if args.build_folder == args.build_dest:
         parser.error("--build-folder and --build-dest cannot be the same")
@@ -394,17 +498,14 @@ def parse_arguments():
     if not args.render_conformance_tests and args.copy_conformance_tests:
         parser.error("--copy-conformance-tests requires --conformance-tests-script to be set")
 
-    if not args.log_to_file and args.log_file_name != DEFAULT_LOG_FILE_NAME:
+    if not args.log_to_file and args.argument_sources.get("log_file_name") != "default":
         parser.error("--log-file-name cannot be used when --log-to-file is False.")
 
     if args.full_plain and args.dry_run:
         parser.error("--full-plain and --dry-run are mutually exclusive")
 
-    if args.status and (args.dry_run or args.full_plain):
-        parser.error("--status cannot be used with --dry-run or --full-plain")
-
     script_arg_names = [UNIT_TESTS_SCRIPT_NAME, CONFORMANCE_TESTS_SCRIPT_NAME, PREPARE_ENVIRONMENT_SCRIPT_NAME]
     for script_name in script_arg_names:
-        args = process_test_script_path(script_name, args)
+        _resolve_script_path(script_name, args, cwd, config_dir, spec_dir)
 
     return args

--- a/plain2code_cli.md
+++ b/plain2code_cli.md
@@ -1,0 +1,78 @@
+# Plain2Code CLI Reference
+
+```text
+[1;34musage: [0m[1;35mgenerate_cli.py[0m [[32m-h[0m] [[36m--verbose[0m] [[36m--base-folder [33mBASE_FOLDER[0m] [[36m--build-folder [33mBUILD_FOLDER[0m] [[36m--log-to-file | --no-log-to-file[0m] [[36m--log-file-name [33mLOG_FILE_NAME[0m]
+                       [[36m--config-name [33mCONFIG_NAME[0m] [[36m--render-range [33mRENDER_RANGE[0m | [36m--render-from [33mRENDER_FROM[0m] [[36m--force-render[0m] [[36m--unittests-script [33mUNITTESTS_SCRIPT[0m]
+                       [[36m--conformance-tests-folder [33mCONFORMANCE_TESTS_FOLDER[0m] [[36m--conformance-tests-script [33mCONFORMANCE_TESTS_SCRIPT[0m]
+                       [[36m--prepare-environment-script [33mPREPARE_ENVIRONMENT_SCRIPT[0m] [[36m--test-script-timeout [33mTEST_SCRIPT_TIMEOUT[0m] [[36m--api [33m[API][0m] [[36m--api-key [33mAPI_KEY[0m] [[36m--full-plain[0m] [[36m--dry-run[0m]
+                       [[36m--replay-with [33mREPLAY_WITH[0m] [[36m--template-dir [33mTEMPLATE_DIR[0m] [[36m--copy-build[0m] [[36m--build-dest [33mBUILD_DEST[0m] [[36m--copy-conformance-tests[0m]
+                       [[36m--conformance-tests-dest [33mCONFORMANCE_TESTS_DEST[0m] [[36m--render-machine-graph[0m] [[36m--logging-config-path [33mLOGGING_CONFIG_PATH[0m] [[36m--headless[0m] [[36m--status[0m] [[36m--version[0m]
+                       [32m[filename][0m
+
+Render plain code to target code. Path arguments resolve based on where they were written: values given on the command line are resolved against the current working directory, values
+read from config.yaml are resolved against the config file's directory, and defaults are resolved against the directory containing the plain file. Absolute paths (and paths starting
+with '~') are used as-is.
+
+[1;34mpositional arguments:[0m
+  [1;32mfilename[0m              Path to the plain file to render. The directory containing this file has highest precedence for template loading, so you can place custom templates here to
+                        override the defaults. See --template-dir for more details about template loading.
+
+[1;34moptions:[0m
+  [1;32m-h[0m, [1;36m--help[0m            show this help message and exit
+  [1;36m--verbose[0m, [1;32m-v[0m         Set default log level to DEBUG for TUI and file logs
+  [1;36m--base-folder[0m [1;33mBASE_FOLDER[0m
+                        Base folder for the build files
+  [1;36m--build-folder[0m [1;33mBUILD_FOLDER[0m
+                        Folder for build files
+  [1;36m--log-to-file[0m, [1;36m--no-log-to-file[0m
+                        Enable logging to a file. Defaults to True. Set to False to disable.
+  [1;36m--log-file-name[0m [1;33mLOG_FILE_NAME[0m
+                        Name of the log file. Defaults to 'codeplain.log'. If a file already exists at the resolved path, it will be overwritten by the current logs.
+  [1;36m--render-range[0m [1;33mRENDER_RANGE[0m
+                        Specify a range of functionalities to render (e.g. `1` , `2`, `3`). Use comma to separate start and end IDs. If only one functionality ID is provided, only that
+                        functionality is rendered. Range is inclusive of both start and end IDs.
+  [1;36m--render-from[0m [1;33mRENDER_FROM[0m
+                        Continue generation starting from this specific functionality (e.g. `2`). The functionality with this ID will be included in the output. The functionality ID
+                        must match one of the functionalities in your plain file.
+  [1;36m--force-render[0m        Force re-render of all the required modules.
+  [1;36m--unittests-script[0m [1;33mUNITTESTS_SCRIPT[0m
+                        Shell script to run unit tests on generated code. Receives the build folder path as its first argument (default: 'plain_modules').
+  [1;36m--conformance-tests-folder[0m [1;33mCONFORMANCE_TESTS_FOLDER[0m
+                        Folder for conformance test files
+  [1;36m--conformance-tests-script[0m [1;33mCONFORMANCE_TESTS_SCRIPT[0m
+                        Path to conformance tests shell script. Every conformance test script should accept two arguments: 1) Path to a folder (e.g. `plain_modules/module_name`)
+                        containing generated source code, 2) Path to a subfolder of the conformance tests folder (e.g. `conformance_tests/subfoldername`) containing test files.
+  [1;36m--prepare-environment-script[0m [1;33mPREPARE_ENVIRONMENT_SCRIPT[0m
+                        Path to a shell script that prepares the testing environment. The script should accept the source code folder path as its first argument.
+  [1;36m--test-script-timeout[0m [1;33mTEST_SCRIPT_TIMEOUT[0m
+                        Timeout for test scripts in seconds. If not provided, the default timeout of 120 seconds is used.
+  [1;36m--api[0m [1;33m[API][0m           Alternative base URL for the API. Default: `https://api.codeplain.ai`
+  [1;36m--api-key[0m [1;33mAPI_KEY[0m     API key used to access the API. If not provided, the `CODEPLAIN_API_KEY` environment variable is used.
+  [1;36m--full-plain[0m          Full preview ***plain specification before code generation. Use when you want to preview context of all ***plain primitives that are going to be included in
+                        order to render the given module.
+  [1;36m--dry-run[0m             Dry run preview of the code generation (without actually making any changes).
+  [1;36m--replay-with[0m [1;33mREPLAY_WITH[0m
+  [1;36m--template-dir[0m [1;33mTEMPLATE_DIR[0m
+                        Path to a custom template directory. Templates are searched in the following order: 1) Directory containing the plain file, 2) Custom template directory (if
+                        provided through this argument), 3) Built-in standard_template_library directory
+  [1;36m--copy-build[0m          If set, copy the rendered contents of code in `--base-folder` folder to `--build-dest` folder after successful rendering.
+  [1;36m--build-dest[0m [1;33mBUILD_DEST[0m
+                        Target folder to copy rendered contents of code to (used only if --copy-build is set).
+  [1;36m--copy-conformance-tests[0m
+                        If set, copy the conformance tests of code in `--conformance-tests-folder` folder to `--conformance-tests-dest` folder successful rendering. Requires
+                        --conformance-tests-script.
+  [1;36m--conformance-tests-dest[0m [1;33mCONFORMANCE_TESTS_DEST[0m
+                        Target folder to copy conformance tests of code to (used only if --copy-conformance-tests is set).
+  [1;36m--render-machine-graph[0m
+                        If set, render the state machine graph.
+  [1;36m--logging-config-path[0m [1;33mLOGGING_CONFIG_PATH[0m
+                        Path to the logging configuration file.
+  [1;36m--headless[0m            Run in headless mode: no TUI, no terminal output except a single render-started message. All logs are written to the log file.
+  [1;36m--status[0m              Display account status including user information, API key label, and rendering credits. Does not render any code.
+  [1;36m--version[0m             Display the client version and exit.
+
+[1;34mconfiguration:[0m
+  [1;36m--config-name[0m [1;33mCONFIG_NAME[0m
+                        Name of the config file to look for. Looked up in the plain file directory and the current working directory. Defaults to config.yaml.
+
+```

--- a/plain2code_console.py
+++ b/plain2code_console.py
@@ -1,4 +1,5 @@
 import logging
+import os
 
 from rich.console import Console
 from rich.style import Style
@@ -87,7 +88,7 @@ class Plain2CodeConsole(Console):
         """
         tree = Tree(root_folder)
         for path, content in files.items():
-            parts = path.split("/")
+            parts = path.split(os.sep)
             current_level = tree
             for part in parts:
                 existing_level = None

--- a/plain2code_logger.py
+++ b/plain2code_logger.py
@@ -1,7 +1,5 @@
 import logging
-import os
 import time
-from typing import Optional
 
 from event_bus import EventBus
 from plain2code_events import LogMessageEmitted
@@ -16,12 +14,19 @@ LOGGER_NAME = "codeplain"
 # same message twice: once in plain text (from lastResort) and once styled (from rich).
 logging.getLogger(LOGGER_NAME).addHandler(logging.NullHandler())
 
+FILE_LOG_FORMAT = "%(asctime)s %(levelname)s %(name)s: %(message)s"
+FILE_LOG_DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
+
 
 class IndentedFormatter(logging.Formatter):
+    def __init__(self, fmt=None, datefmt=None, indent=16):
+        super().__init__(fmt=fmt, datefmt=datefmt)
+        self._indent = " " * indent
+
     def format(self, record):
         original_message = record.getMessage()
 
-        modified_message = original_message.replace("\n", "\n                ")
+        modified_message = original_message.replace("\n", "\n" + self._indent)
 
         record.msg = modified_message
         return super().format(record)
@@ -118,26 +123,16 @@ class CrashLogHandler(logging.Handler):
             return False
 
 
-def get_log_file_path(plain_file_path: Optional[str], log_file_name: str) -> Optional[str]:
-    """Get the full path to the log file, relative to the plain file directory."""
-    if not plain_file_path:
-        return None
-    plain_dir = os.path.dirname(os.path.abspath(plain_file_path))
-    return os.path.join(plain_dir, log_file_name)
-
-
 def dump_crash_logs(args, run_state: RunState, formatter=None):
     """Dump buffered logs to file if CrashLogHandler is present."""
     if args.log_to_file:
         return
 
     if formatter is None:
-        formatter = ElapsedTimeFormatter(run_state)
+        formatter = IndentedFormatter(FILE_LOG_FORMAT, datefmt=FILE_LOG_DATE_FORMAT, indent=len("YYYY-MM-DD HH:MM:SS "))
 
     root_logger = logging.getLogger(LOGGER_NAME)
     crash_handler = next((h for h in root_logger.handlers if isinstance(h, CrashLogHandler)), None)
 
     if crash_handler and args.filename:
-        log_file_path = get_log_file_path(args.filename, args.log_file_name)
-
-        crash_handler.dump_to_file(log_file_path, formatter)
+        crash_handler.dump_to_file(args.log_file_name, formatter)

--- a/test_scripts/run_conformance_tests_cypress.ps1
+++ b/test_scripts/run_conformance_tests_cypress.ps1
@@ -69,6 +69,17 @@ function Cleanup {
     if ($script:build_output -and (Test-Path $script:build_output)) {
         Remove-Item $script:build_output -Force -ErrorAction SilentlyContinue
     }
+
+    # Step out of any temp subfolder we may still be in before deleting it
+    Set-Location -Path ([System.IO.Path]::GetTempPath()) -ErrorAction SilentlyContinue
+
+    # Remove temporary build subfolders if they exist
+    if ($script:NODE_SUBFOLDER -and (Test-Path $script:NODE_SUBFOLDER)) {
+        Remove-Item -Path $script:NODE_SUBFOLDER -Recurse -Force -ErrorAction SilentlyContinue
+    }
+    if ($script:NODE_CONFORMANCE_TESTS_SUBFOLDER -and (Test-Path $script:NODE_CONFORMANCE_TESTS_SUBFOLDER)) {
+        Remove-Item -Path $script:NODE_CONFORMANCE_TESTS_SUBFOLDER -Recurse -Force -ErrorAction SilentlyContinue
+    }
 }
 
 # Check for and kill any existing Node server from previous runs
@@ -99,19 +110,19 @@ $current_dir = Get-Location
 
 try {
     # Define the path to the subfolder
-    $NODE_SUBFOLDER = "node_$BuildFolder"
+    $script:NODE_SUBFOLDER = Join-Path ([System.IO.Path]::GetTempPath()) "node_$(Split-Path $BuildFolder -Leaf)"
 
     # Running React application
-    Write-Host "### Step 1: Starting the React application in folder $NODE_SUBFOLDER..."
+    Write-Host "### Step 1: Starting the React application in folder $script:NODE_SUBFOLDER..."
 
     if ($env:VERBOSE -eq "1") {
-        Write-Host "Preparing Node subfolder: $NODE_SUBFOLDER"
+        Write-Host "Preparing Node subfolder: $script:NODE_SUBFOLDER"
     }
 
     # Check if the node subfolder exists
-    if (Test-Path $NODE_SUBFOLDER) {
+    if (Test-Path $script:NODE_SUBFOLDER) {
         # Delete all files and folders except "node_modules", "plain_modules", and "package-lock.json"
-        Get-ChildItem -Path $NODE_SUBFOLDER -Force |
+        Get-ChildItem -Path $script:NODE_SUBFOLDER -Force |
             Where-Object {
                 $_.Name -ne "node_modules" -and
                 $_.Name -ne "plain_modules" -and
@@ -126,18 +137,18 @@ try {
             Write-Host "Subfolder does not exist. Creating it..."
         }
 
-        New-Item -ItemType Directory -Path $NODE_SUBFOLDER -Force | Out-Null
+        New-Item -ItemType Directory -Path $script:NODE_SUBFOLDER -Force | Out-Null
     }
 
-    Copy-Item -Path "$BuildFolder/*" -Destination $NODE_SUBFOLDER -Recurse -Force
+    Copy-Item -Path "$BuildFolder/*" -Destination $script:NODE_SUBFOLDER -Recurse -Force
 
     # Move to the subfolder
-    if (-not (Test-Path $NODE_SUBFOLDER)) {
-        Write-Host "Error: Node build folder '$NODE_SUBFOLDER' does not exist."
+    if (-not (Test-Path $script:NODE_SUBFOLDER)) {
+        Write-Host "Error: Node build folder '$script:NODE_SUBFOLDER' does not exist."
         exit $UNRECOVERABLE_ERROR_EXIT_CODE
     }
 
-    Push-Location $NODE_SUBFOLDER
+    Push-Location $script:NODE_SUBFOLDER
 
     # Temporarily allow stderr output without throwing (npm may write warnings to stderr)
     # ForEach-Object converts ErrorRecord objects (from stderr) to plain strings to avoid verbose error formatting
@@ -246,16 +257,16 @@ try {
     Set-Location $current_dir
 
     # Define the path to the conformance tests subfolder
-    $NODE_CONFORMANCE_TESTS_SUBFOLDER = "node_$ConformanceTestsFolder"
+    $script:NODE_CONFORMANCE_TESTS_SUBFOLDER = Join-Path ([System.IO.Path]::GetTempPath()) "node_$(Split-Path $ConformanceTestsFolder -Leaf)"
 
     if ($env:VERBOSE -eq "1") {
-        Write-Host "Preparing conformance tests Node subfolder: $NODE_CONFORMANCE_TESTS_SUBFOLDER"
+        Write-Host "Preparing conformance tests Node subfolder: $script:NODE_CONFORMANCE_TESTS_SUBFOLDER"
     }
 
     # Check if the conformance tests node subfolder exists
-    if (Test-Path $NODE_CONFORMANCE_TESTS_SUBFOLDER) {
+    if (Test-Path $script:NODE_CONFORMANCE_TESTS_SUBFOLDER) {
         # Delete all files and folders except "node_modules", "plain_modules", and "package-lock.json"
-        Get-ChildItem -Path $NODE_CONFORMANCE_TESTS_SUBFOLDER -Force |
+        Get-ChildItem -Path $script:NODE_CONFORMANCE_TESTS_SUBFOLDER -Force |
             Where-Object {
                 $_.Name -ne "node_modules" -and
                 $_.Name -ne "plain_modules" -and
@@ -270,18 +281,18 @@ try {
             Write-Host "Subfolder does not exist. Creating it..."
         }
 
-        New-Item -ItemType Directory -Path $NODE_CONFORMANCE_TESTS_SUBFOLDER -Force | Out-Null
+        New-Item -ItemType Directory -Path $script:NODE_CONFORMANCE_TESTS_SUBFOLDER -Force | Out-Null
     }
 
-    Copy-Item -Path "$ConformanceTestsFolder/*" -Destination $NODE_CONFORMANCE_TESTS_SUBFOLDER -Recurse -Force
+    Copy-Item -Path "$ConformanceTestsFolder/*" -Destination $script:NODE_CONFORMANCE_TESTS_SUBFOLDER -Recurse -Force
 
     # Move to the subfolder with Cypress tests
-    if (-not (Test-Path $NODE_CONFORMANCE_TESTS_SUBFOLDER)) {
-        Write-Host "Error: conformance tests Node folder '$NODE_CONFORMANCE_TESTS_SUBFOLDER' does not exist."
+    if (-not (Test-Path $script:NODE_CONFORMANCE_TESTS_SUBFOLDER)) {
+        Write-Host "Error: conformance tests Node folder '$script:NODE_CONFORMANCE_TESTS_SUBFOLDER' does not exist."
         exit $UNRECOVERABLE_ERROR_EXIT_CODE
     }
 
-    Push-Location $NODE_CONFORMANCE_TESTS_SUBFOLDER
+    Push-Location $script:NODE_CONFORMANCE_TESTS_SUBFOLDER
 
     # Temporarily allow stderr output without throwing (npm may write warnings to stderr)
     # ForEach-Object converts ErrorRecord objects (from stderr) to plain strings to avoid verbose error formatting

--- a/test_scripts/run_conformance_tests_cypress.sh
+++ b/test_scripts/run_conformance_tests_cypress.sh
@@ -63,6 +63,10 @@ cleanup() {
 
     # Remove temporary files if they exist
     [ -f "$build_output" ] && rm "$build_output" 2>/dev/null
+
+    # Remove temporary build subfolders if they exist
+    [ -n "${NODE_SUBFOLDER:-}" ] && rm -rf "$NODE_SUBFOLDER"
+    [ -n "${NODE_CONFORMANCE_TESTS_SUBFOLDER:-}" ] && rm -rf "$NODE_CONFORMANCE_TESTS_SUBFOLDER"
 }
 
 # Set up trap to call cleanup function on script exit, interrupt, or termination
@@ -96,7 +100,7 @@ current_dir=$(pwd)
 set -o pipefail
 
 # Define the path to the subfolder
-NODE_SUBFOLDER=node_$1
+NODE_SUBFOLDER="/tmp/node_$(basename "$1")"
 
 # Running React application
 printf "### Step 1: Starting the React application in folder $NODE_SUBFOLDER...\n"
@@ -206,7 +210,7 @@ printf "### Step 2: Running Cypress conformance tests $2...\n"
 cd $current_dir
 
 # Define the path to the conformance tests subfolder
-NODE_CONFORMANCE_TESTS_SUBFOLDER=node_$2
+NODE_CONFORMANCE_TESTS_SUBFOLDER="/tmp/node_$(basename "$2")"
 
 if [ "${VERBOSE:-}" -eq 1 ] 2>/dev/null; then
   printf "Preparing conformance tests Node subfolder: $NODE_CONFORMANCE_TESTS_SUBFOLDER\n"

--- a/test_scripts/run_conformance_tests_golang.ps1
+++ b/test_scripts/run_conformance_tests_golang.ps1
@@ -23,7 +23,13 @@ $ConformanceTestsFolder = $args[1]
 
 $current_dir = Get-Location
 
-$GO_BUILD_SUBFOLDER = "go_$BuildFolder"
+# Resolve conformance tests folder to an absolute path so it can be used
+# from the build subfolder (where we'll Push-Location to next).
+if (-not [System.IO.Path]::IsPathRooted($ConformanceTestsFolder)) {
+    $ConformanceTestsFolder = Join-Path $current_dir $ConformanceTestsFolder
+}
+
+$GO_BUILD_SUBFOLDER = Join-Path ([System.IO.Path]::GetTempPath()) "go_$(Split-Path $BuildFolder -Leaf)"
 
 if ($env:VERBOSE -eq "1") {
     Write-Host "Preparing Go build subfolder: $GO_BUILD_SUBFOLDER"
@@ -60,9 +66,9 @@ try {
     go get
 
     # Move to conformance tests folder
-    Set-Location "$current_dir/$ConformanceTestsFolder"
+    Set-Location $ConformanceTestsFolder
     if ($LASTEXITCODE -and $LASTEXITCODE -ne 0) {
-        Write-Host "Error: Conformance tests folder '$current_dir/$ConformanceTestsFolder' does not exist."
+        Write-Host "Error: Conformance tests folder '$ConformanceTestsFolder' does not exist."
         exit $UNRECOVERABLE_ERROR_EXIT_CODE
     }
 
@@ -75,7 +81,7 @@ try {
     }
 
     # Move back to build directory
-    Set-Location "$current_dir/$GO_BUILD_SUBFOLDER"
+    Set-Location $GO_BUILD_SUBFOLDER
 
     # Execute Go lang conformance tests
     Write-Host "Running Golang conformance tests...`n"
@@ -83,7 +89,7 @@ try {
     # Temporarily allow stderr output without throwing (Go may write to stderr)
     # ForEach-Object converts ErrorRecord objects (from stderr) to plain strings to avoid verbose error formatting
     $ErrorActionPreference = 'Continue'
-    $output = go run "$current_dir/$ConformanceTestsFolder/conformance_tests.go" 2>&1 | ForEach-Object { if ($_ -is [System.Management.Automation.ErrorRecord]) { $_.Exception.Message } else { $_ } } | Out-String
+    $output = go run (Join-Path $ConformanceTestsFolder "conformance_tests.go") 2>&1 | ForEach-Object { if ($_ -is [System.Management.Automation.ErrorRecord]) { $_.Exception.Message } else { $_ } } | Out-String
     $exit_code = $LASTEXITCODE
     $ErrorActionPreference = 'Stop'
 
@@ -97,4 +103,7 @@ try {
     exit $exit_code
 } finally {
     Pop-Location
+    if (Test-Path $GO_BUILD_SUBFOLDER) {
+        Remove-Item -Path $GO_BUILD_SUBFOLDER -Recurse -Force -ErrorAction SilentlyContinue
+    }
 }

--- a/test_scripts/run_conformance_tests_golang.sh
+++ b/test_scripts/run_conformance_tests_golang.sh
@@ -16,9 +16,9 @@ if [ -z "$2" ]; then
   exit $UNRECOVERABLE_ERROR_EXIT_CODE
 fi
 
-current_dir=$(pwd)
+GO_BUILD_SUBFOLDER="/tmp/go_$(basename "$1")"
 
-GO_BUILD_SUBFOLDER=go_$1
+trap 'rm -rf "$GO_BUILD_SUBFOLDER"' EXIT
 
 if [ "${VERBOSE:-}" -eq 1 ] 2>/dev/null; then
   printf "Preparing Go build subfolder: $GO_BUILD_SUBFOLDER\n"
@@ -53,10 +53,10 @@ fi
 echo "Runinng go get in the build folder..."
 go get
 
-cd "$current_dir/$2" 2>/dev/null
+cd "$2" 2>/dev/null
 
 if [ $? -ne 0 ]; then
-  printf "Error: Conformance tests folder '$current_dir/$2' does not exist.\n"
+  printf "Error: Conformance tests folder '$2' does not exist.\n"
   exit $UNRECOVERABLE_ERROR_EXIT_CODE
 fi
 
@@ -69,12 +69,12 @@ else
 fi
 
 # Move back to build directory
-cd "$current_dir/$GO_BUILD_SUBFOLDER" 2>/dev/null
+cd "$GO_BUILD_SUBFOLDER" 2>/dev/null
 
 # Execute Go lang conformance tests
 printf "Running Golang conformance tests...\n\n"
 
-output=$(go run $current_dir/$2/conformance_tests.go 2>&1)
+output=$(go run "$2/conformance_tests.go" 2>&1)
 exit_code=$?
 
 # If there was an error, print the output and exit with the error code

--- a/test_scripts/run_conformance_tests_python.ps1
+++ b/test_scripts/run_conformance_tests_python.ps1
@@ -33,7 +33,13 @@ if (Get-Command python3 -ErrorAction SilentlyContinue) {
 
 $current_dir = Get-Location
 
-$PYTHON_BUILD_SUBFOLDER = "python_$BuildFolder"
+# Resolve conformance tests folder to an absolute path so it can be used
+# from the build subfolder (where we'll Push-Location to next).
+if (-not [System.IO.Path]::IsPathRooted($ConformanceTestsFolder)) {
+    $ConformanceTestsFolder = Join-Path $current_dir $ConformanceTestsFolder
+}
+
+$PYTHON_BUILD_SUBFOLDER = Join-Path ([System.IO.Path]::GetTempPath()) "python_$(Split-Path $BuildFolder -Leaf)"
 
 if ($env:VERBOSE -eq "1") {
     Write-Host "Preparing Python build subfolder: $PYTHON_BUILD_SUBFOLDER"
@@ -72,7 +78,7 @@ try {
     # Temporarily allow stderr output without throwing (Python unittest writes progress to stderr)
     # ForEach-Object converts ErrorRecord objects (from stderr) to plain strings to avoid verbose error formatting
     $ErrorActionPreference = 'Continue'
-    $output = & $PYTHON_CMD -m unittest discover -b -s "$current_dir/$ConformanceTestsFolder" 2>&1 | ForEach-Object { if ($_ -is [System.Management.Automation.ErrorRecord]) { $_.Exception.Message } else { $_ } } | Out-String
+    $output = & $PYTHON_CMD -m unittest discover -b -s $ConformanceTestsFolder 2>&1 | ForEach-Object { if ($_ -is [System.Management.Automation.ErrorRecord]) { $_.Exception.Message } else { $_ } } | Out-String
     $exit_code = $LASTEXITCODE
     $ErrorActionPreference = 'Stop'
 
@@ -89,4 +95,7 @@ try {
     exit $exit_code
 } finally {
     Pop-Location
+    if (Test-Path $PYTHON_BUILD_SUBFOLDER) {
+        Remove-Item -Path $PYTHON_BUILD_SUBFOLDER -Recurse -Force -ErrorAction SilentlyContinue
+    }
 }

--- a/test_scripts/run_conformance_tests_python.sh
+++ b/test_scripts/run_conformance_tests_python.sh
@@ -26,9 +26,9 @@ else
     exit $UNRECOVERABLE_ERROR_EXIT_CODE
 fi
 
-current_dir=$(pwd)
+PYTHON_BUILD_SUBFOLDER="/tmp/python_$(basename "$1")"
 
-PYTHON_BUILD_SUBFOLDER=python_$1
+trap 'rm -rf "$PYTHON_BUILD_SUBFOLDER"' EXIT
 
 if [ "${VERBOSE:-}" -eq 1 ] 2>/dev/null; then
   printf "Preparing Python build subfolder: $PYTHON_BUILD_SUBFOLDER\n"
@@ -63,7 +63,7 @@ fi
 # Execute all Python conformance tests in the build folder
 printf "Running Python conformance tests...\n\n"
 
-output=$($PYTHON_CMD -m unittest discover -b -s "$current_dir/$2" 2>&1)
+output=$($PYTHON_CMD -m unittest discover -b -s "$2" 2>&1)
 exit_code=$?
 
 # Echo the original output

--- a/test_scripts/run_unittests_flutter.ps1
+++ b/test_scripts/run_unittests_flutter.ps1
@@ -16,7 +16,7 @@ if (-not (Get-Command flutter -ErrorAction SilentlyContinue)) {
 }
 
 $SOURCE_FOLDER = $args[0]
-$BUILD_SUBFOLDER = ".tmp/flutter_build_unittests"
+$BUILD_SUBFOLDER = Join-Path ([System.IO.Path]::GetTempPath()) "flutter_$(Split-Path $SOURCE_FOLDER -Leaf)"
 
 Write-Host "Current directory: $(Get-Location)"
 Write-Host "Source folder: $SOURCE_FOLDER"
@@ -79,4 +79,7 @@ try {
     Remove-Item -Path "flutter_test_stdout.txt" -ErrorAction SilentlyContinue
     Remove-Item -Path "flutter_test_stderr.txt" -ErrorAction SilentlyContinue
     Pop-Location
+    if (Test-Path $BUILD_SUBFOLDER) {
+        Remove-Item -Path $BUILD_SUBFOLDER -Recurse -Force -ErrorAction SilentlyContinue
+    }
 }

--- a/test_scripts/run_unittests_flutter.sh
+++ b/test_scripts/run_unittests_flutter.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+UNRECOVERABLE_ERROR_EXIT_CODE=69
+
+if [ -z "$1" ]; then
+  echo "Error: No source folder name provided."
+  echo "Usage: $0 <source_folder_name>"
+  exit $UNRECOVERABLE_ERROR_EXIT_CODE
+fi
+
+if ! command -v flutter >/dev/null 2>&1; then
+  echo "Error: flutter is not available in PATH."
+  exit $UNRECOVERABLE_ERROR_EXIT_CODE
+fi
+
+current_dir=$(pwd)
+SOURCE_FOLDER=$1
+BUILD_SUBFOLDER="/tmp/flutter_$(basename "$1")"
+
+trap 'rm -rf "$BUILD_SUBFOLDER"' EXIT
+
+echo "Current directory: $current_dir"
+echo "Source folder: $SOURCE_FOLDER"
+echo "--------------------------------"
+
+if [ -d "$BUILD_SUBFOLDER" ]; then
+  rm -rf "$BUILD_SUBFOLDER"
+fi
+mkdir -p "$BUILD_SUBFOLDER"
+
+cp -R $SOURCE_FOLDER/* "$BUILD_SUBFOLDER/"
+
+cd "$BUILD_SUBFOLDER" || exit $UNRECOVERABLE_ERROR_EXIT_CODE
+
+printf "Resolving Flutter dependencies...\n"
+
+if [ -f "pubspec.yaml" ]; then
+    flutter pub get
+else
+    echo "Warning: pubspec.yaml not found. Dependencies might be missing."
+fi
+
+echo "Running Flutter unittests in $BUILD_SUBFOLDER..."
+
+output=$(timeout 120s flutter test --reporter expanded 2>&1)
+exit_code=$?
+
+if [ $exit_code -eq 124 ]; then
+    printf "\nError: Unittests timed out after 120 seconds.\n"
+    exit $exit_code
+fi
+
+echo "$output"
+
+exit $exit_code

--- a/test_scripts/run_unittests_golang.ps1
+++ b/test_scripts/run_unittests_golang.ps1
@@ -13,7 +13,7 @@ if (-not $args[0]) {
 
 $BuildFolder = $args[0]
 
-$GO_BUILD_SUBFOLDER = "go_$BuildFolder"
+$GO_BUILD_SUBFOLDER = Join-Path ([System.IO.Path]::GetTempPath()) "go_$(Split-Path $BuildFolder -Leaf)"
 
 if ($env:VERBOSE -eq "1") {
     Write-Host "Preparing Go build subfolder: $GO_BUILD_SUBFOLDER"
@@ -65,4 +65,7 @@ try {
     exit $exit_code
 } finally {
     Pop-Location
+    if (Test-Path $GO_BUILD_SUBFOLDER) {
+        Remove-Item -Path $GO_BUILD_SUBFOLDER -Recurse -Force -ErrorAction SilentlyContinue
+    }
 }

--- a/test_scripts/run_unittests_golang.sh
+++ b/test_scripts/run_unittests_golang.sh
@@ -9,7 +9,9 @@ if [ -z "$1" ]; then
   exit $UNRECOVERABLE_ERROR_EXIT_CODE
 fi
 
-GO_BUILD_SUBFOLDER=go_$1
+GO_BUILD_SUBFOLDER="/tmp/go_$(basename "$1")"
+
+trap 'rm -rf "$GO_BUILD_SUBFOLDER"' EXIT
 
 if [ "${VERBOSE:-}" -eq 1 ] 2>/dev/null; then
   printf "Preparing Go build subfolder: $GO_BUILD_SUBFOLDER\n"

--- a/test_scripts/run_unittests_python.ps1
+++ b/test_scripts/run_unittests_python.ps1
@@ -23,7 +23,7 @@ if (Get-Command python3 -ErrorAction SilentlyContinue) {
     exit $UNRECOVERABLE_ERROR_EXIT_CODE
 }
 
-$PYTHON_BUILD_SUBFOLDER = "python_$BuildFolder"
+$PYTHON_BUILD_SUBFOLDER = Join-Path ([System.IO.Path]::GetTempPath()) "python_$(Split-Path $BuildFolder -Leaf)"
 
 if ($env:VERBOSE -eq "1") {
     Write-Host "Preparing Python build subfolder: $PYTHON_BUILD_SUBFOLDER"
@@ -73,4 +73,7 @@ try {
     exit $exit_code
 } finally {
     Pop-Location
+    if (Test-Path $PYTHON_BUILD_SUBFOLDER) {
+        Remove-Item -Path $PYTHON_BUILD_SUBFOLDER -Recurse -Force -ErrorAction SilentlyContinue
+    }
 }

--- a/test_scripts/run_unittests_python.sh
+++ b/test_scripts/run_unittests_python.sh
@@ -19,7 +19,9 @@ else
     exit $UNRECOVERABLE_ERROR_EXIT_CODE
 fi
 
-PYTHON_BUILD_SUBFOLDER=python_$1
+PYTHON_BUILD_SUBFOLDER="/tmp/python_$(basename "$1")"
+
+trap 'rm -rf "$PYTHON_BUILD_SUBFOLDER"' EXIT
 
 if [ "${VERBOSE:-}" -eq 1 ] 2>/dev/null; then
   printf "Preparing Python build subfolder: $PYTHON_BUILD_SUBFOLDER\n"

--- a/test_scripts/run_unittests_react.ps1
+++ b/test_scripts/run_unittests_react.ps1
@@ -17,7 +17,7 @@ if (-not $args[0]) {
 $BuildFolder = $args[0]
 
 # Define the path to the subfolder
-$NODE_SUBFOLDER = "node_$BuildFolder"
+$NODE_SUBFOLDER = Join-Path ([System.IO.Path]::GetTempPath()) "node_$(Split-Path $BuildFolder -Leaf)"
 
 if ($env:VERBOSE -eq "1") {
     Write-Host "Preparing Node subfolder: $NODE_SUBFOLDER"
@@ -80,4 +80,7 @@ try {
     exit $TEST_EXIT_CODE
 } finally {
     Pop-Location
+    if (Test-Path $NODE_SUBFOLDER) {
+        Remove-Item -Path $NODE_SUBFOLDER -Recurse -Force -ErrorAction SilentlyContinue
+    }
 }

--- a/test_scripts/run_unittests_react.sh
+++ b/test_scripts/run_unittests_react.sh
@@ -17,7 +17,9 @@ if [ -z "$1" ]; then
 fi
 
 # Define the path to the subfolder
-NODE_SUBFOLDER=node_$1
+NODE_SUBFOLDER="/tmp/node_$(basename "$1")"
+
+trap 'rm -rf "$NODE_SUBFOLDER"' EXIT
 
 if [ "${VERBOSE:-}" -eq 1 ] 2>/dev/null; then
   printf "Preparing Node subfolder: $NODE_SUBFOLDER\n"

--- a/tests/test_arg_provenance.py
+++ b/tests/test_arg_provenance.py
@@ -1,0 +1,89 @@
+"""Tests for argument-source provenance tracking in plain2code_arguments."""
+
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from plain2code_arguments import ARGUMENT_SOURCES, parse_arguments
+
+
+@pytest.fixture
+def project():
+    """Temporary directory with a plain file. CWD is patched to the same directory."""
+    with tempfile.TemporaryDirectory() as d:
+        (Path(d) / "module.plain").write_text("")
+        with patch("os.getcwd", return_value=d):
+            yield d
+
+
+def _sources(args):
+    return getattr(args, ARGUMENT_SOURCES)
+
+
+def test_default_when_neither_cli_nor_config(project):
+    args = parse_arguments([os.path.join(project, "module.plain")])
+    assert _sources(args)["build_folder"] == "default"
+    assert _sources(args)["conformance_tests_folder"] == "default"
+
+
+def test_cli_value_is_marked_as_cli(project):
+    args = parse_arguments([os.path.join(project, "module.plain"), "--build-folder", "out"])
+    assert _sources(args)["build_folder"] == "cli"
+    assert args.build_folder == os.path.join(project, "out")
+
+
+def test_cli_value_equal_to_default_is_still_cli(project):
+    """Passing the literal default on the CLI is still an explicit CLI choice."""
+    args = parse_arguments([os.path.join(project, "module.plain"), "--build-folder", "plain_modules"])
+    assert _sources(args)["build_folder"] == "cli"
+
+
+def test_config_value_is_marked_as_config(project):
+    (Path(project) / "config.yaml").write_text("build-folder: from_config\n")
+    args = parse_arguments([os.path.join(project, "module.plain")])
+    assert _sources(args)["build_folder"] == "config"
+    assert args.build_folder == os.path.join(project, "from_config")
+
+
+def test_cli_wins_over_config(project):
+    (Path(project) / "config.yaml").write_text("build-folder: from_config\n")
+    args = parse_arguments([os.path.join(project, "module.plain"), "--build-folder", "from_cli"])
+    assert _sources(args)["build_folder"] == "cli"
+    assert args.build_folder == os.path.join(project, "from_cli")
+
+
+def test_boolean_flag_provenance(project):
+    """Default is True, but an explicit --no- flag on the CLI overrides it to False."""
+    default_args = parse_arguments([os.path.join(project, "module.plain")])
+    assert default_args.log_to_file is True
+    assert _sources(default_args)["log_to_file"] == "default"
+
+    args = parse_arguments([os.path.join(project, "module.plain"), "--no-log-to-file"])
+    assert _sources(args)["log_to_file"] == "cli"
+    assert args.log_to_file is False
+
+
+def test_boolean_flag_default(project):
+    args = parse_arguments([os.path.join(project, "module.plain")])
+    assert _sources(args)["verbose"] == "default"
+    assert args.verbose is False
+
+
+def test_boolean_flag_from_config(project):
+    (Path(project) / "config.yaml").write_text("verbose: true\n")
+    args = parse_arguments([os.path.join(project, "module.plain")])
+    assert _sources(args)["verbose"] == "config"
+    assert args.verbose is True
+
+
+def test_mixed_sources(project):
+    """CLI, config, and default values coexist on the same invocation."""
+    (Path(project) / "config.yaml").write_text("build-folder: from_config\n")
+    args = parse_arguments([os.path.join(project, "module.plain"), "--conformance-tests-folder", "ct_from_cli"])
+    srcs = _sources(args)
+    assert srcs["conformance_tests_folder"] == "cli"
+    assert srcs["build_folder"] == "config"
+    assert srcs["build_dest"] == "default"

--- a/tests/test_folder_path_resolution.py
+++ b/tests/test_folder_path_resolution.py
@@ -1,0 +1,165 @@
+"""Tests for folder-path argument resolution.
+
+Covers --base-folder, --build-folder, --conformance-tests-folder,
+--build-dest, --conformance-tests-dest, --template-dir.
+
+The rule: CLI values resolve against CWD, config values resolve against
+the config file's directory, and values left at their default (for the
+output folders) resolve against the spec file's directory.
+"""
+
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from plain2code_arguments import (
+    DEFAULT_BUILD_DEST,
+    DEFAULT_BUILD_FOLDER,
+    DEFAULT_CONFORMANCE_TESTS_DEST,
+    DEFAULT_CONFORMANCE_TESTS_FOLDER,
+    parse_arguments,
+)
+
+
+@pytest.fixture
+def layout():
+    """Three separate directories: one for the spec, one for the config, one as CWD."""
+    with tempfile.TemporaryDirectory() as root:
+        spec_dir = Path(root) / "spec_dir"
+        config_dir = Path(root) / "config_dir"
+        cwd = Path(root) / "cwd"
+        spec_dir.mkdir()
+        config_dir.mkdir()
+        cwd.mkdir()
+        (spec_dir / "module.plain").write_text("")
+        yield {
+            "spec": spec_dir,
+            "config": config_dir,
+            "cwd": cwd,
+            "plain_file": str(spec_dir / "module.plain"),
+        }
+
+
+# ---- Default-source resolution (spec-dir-anchored) ------------------------
+
+
+def test_missing_build_folder_defaults_next_to_spec(layout):
+    with patch("os.getcwd", return_value=str(layout["cwd"])):
+        args = parse_arguments([layout["plain_file"]])
+    assert args.build_folder == str(layout["spec"] / DEFAULT_BUILD_FOLDER)
+
+
+def test_missing_conformance_tests_folder_defaults_next_to_spec(layout):
+    with patch("os.getcwd", return_value=str(layout["cwd"])):
+        args = parse_arguments([layout["plain_file"]])
+    assert args.conformance_tests_folder == str(layout["spec"] / DEFAULT_CONFORMANCE_TESTS_FOLDER)
+
+
+def test_missing_build_dest_defaults_next_to_spec(layout):
+    with patch("os.getcwd", return_value=str(layout["cwd"])):
+        args = parse_arguments([layout["plain_file"]])
+    assert args.build_dest == str(layout["spec"] / DEFAULT_BUILD_DEST)
+
+
+def test_missing_conformance_tests_dest_defaults_next_to_spec(layout):
+    with patch("os.getcwd", return_value=str(layout["cwd"])):
+        args = parse_arguments([layout["plain_file"]])
+    assert args.conformance_tests_dest == str(layout["spec"] / DEFAULT_CONFORMANCE_TESTS_DEST)
+
+
+def test_optional_folders_remain_none_when_unset(layout):
+    with patch("os.getcwd", return_value=str(layout["cwd"])):
+        args = parse_arguments([layout["plain_file"]])
+    assert args.base_folder is None
+    assert args.template_dir is None
+
+
+# ---- CLI-source resolution (CWD-anchored) ---------------------------------
+
+
+def test_cli_build_folder_resolves_against_cwd(layout):
+    with patch("os.getcwd", return_value=str(layout["cwd"])):
+        args = parse_arguments([layout["plain_file"], "--build-folder", "out"])
+    assert args.build_folder == str(layout["cwd"] / "out")
+
+
+def test_cli_base_folder_resolves_against_cwd(layout):
+    base = layout["cwd"] / "base"
+    base.mkdir()
+    with patch("os.getcwd", return_value=str(layout["cwd"])):
+        args = parse_arguments([layout["plain_file"], "--base-folder", "base"])
+    assert args.base_folder == str(base)
+
+
+def test_cli_template_dir_resolves_against_cwd(layout):
+    tmpl = layout["cwd"] / "templates"
+    tmpl.mkdir()
+    with patch("os.getcwd", return_value=str(layout["cwd"])):
+        args = parse_arguments([layout["plain_file"], "--template-dir", "templates"])
+    assert args.template_dir == str(tmpl)
+
+
+def test_cli_dotdot_folder_resolves_against_cwd(layout):
+    with patch("os.getcwd", return_value=str(layout["cwd"])):
+        args = parse_arguments([layout["plain_file"], "--build-folder", "../spec_dir/custom_out"])
+    assert args.build_folder == str(layout["spec"] / "custom_out")
+
+
+def test_cli_absolute_path_preserved(layout):
+    abs_path = str(layout["spec"] / "explicit_out")
+    with patch("os.getcwd", return_value=str(layout["cwd"])):
+        args = parse_arguments([layout["plain_file"], "--build-folder", abs_path])
+    assert args.build_folder == abs_path
+
+
+# ---- Config-source resolution (config-dir-anchored) -----------------------
+
+
+def test_config_build_folder_resolves_against_config_dir(layout):
+    (layout["config"] / "config.yaml").write_text("build-folder: out_from_config\n")
+    with patch("os.getcwd", return_value=str(layout["config"])):
+        args = parse_arguments([layout["plain_file"]])
+    assert args.build_folder == str(layout["config"] / "out_from_config")
+
+
+def test_config_all_output_folders_resolve_against_config_dir(layout):
+    (layout["config"] / "config.yaml").write_text(
+        "build-folder: b\n" "conformance-tests-folder: ct\n" "build-dest: d\n" "conformance-tests-dest: cd\n"
+    )
+    with patch("os.getcwd", return_value=str(layout["config"])):
+        args = parse_arguments([layout["plain_file"]])
+    assert args.build_folder == str(layout["config"] / "b")
+    assert args.conformance_tests_folder == str(layout["config"] / "ct")
+    assert args.build_dest == str(layout["config"] / "d")
+    assert args.conformance_tests_dest == str(layout["config"] / "cd")
+
+
+def test_config_template_dir_resolves_against_config_dir(layout):
+    (layout["config"] / "config.yaml").write_text("template-dir: my_templates\n")
+    with patch("os.getcwd", return_value=str(layout["config"])):
+        args = parse_arguments([layout["plain_file"]])
+    assert args.template_dir == str(layout["config"] / "my_templates")
+
+
+def test_cli_overrides_config_and_uses_cwd_anchor(layout):
+    """A CLI flag that overrides a config value must use CLI semantics (CWD)."""
+    (layout["config"] / "config.yaml").write_text("build-folder: from_config\n")
+    with patch("os.getcwd", return_value=str(layout["cwd"])):
+        args = parse_arguments([layout["plain_file"], "--build-folder", "from_cli"])
+    assert args.build_folder == str(layout["cwd"] / "from_cli")
+
+
+# ---- Equality checks happen on resolved paths ----------------------------
+
+
+def test_build_folder_and_build_dest_equality_detected_after_resolution(layout, capsys):
+    """Two different relative paths that resolve to the same absolute path must trip the check."""
+    (layout["config"] / "config.yaml").write_text("build-folder: same\n" "build-dest: same\n")
+    with patch("os.getcwd", return_value=str(layout["config"])):
+        with pytest.raises(SystemExit):
+            parse_arguments([layout["plain_file"]])
+    err = capsys.readouterr().err
+    assert "--build-folder and --build-dest cannot be the same" in err

--- a/tests/test_log_file_name_resolution.py
+++ b/tests/test_log_file_name_resolution.py
@@ -1,0 +1,89 @@
+"""Tests for --log-file-name resolution.
+
+Same frame-of-reference rule as other path arguments: CLI values resolve
+against CWD, config.yaml values resolve against the config file's
+directory, and the default resolves against the spec file's directory.
+
+Also verifies the "--log-file-name cannot be used when --log-to-file is
+False" validation now uses the recorded argument source rather than a
+string-equality heuristic against the default.
+"""
+
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from plain2code_arguments import DEFAULT_LOG_FILE_NAME, parse_arguments
+
+
+@pytest.fixture
+def layout():
+    """Three separate directories: spec dir, config dir, and CWD."""
+    with tempfile.TemporaryDirectory() as root:
+        spec_dir = Path(root) / "spec_dir"
+        config_dir = Path(root) / "config_dir"
+        cwd = Path(root) / "cwd"
+        spec_dir.mkdir()
+        config_dir.mkdir()
+        cwd.mkdir()
+        (spec_dir / "module.plain").write_text("")
+        yield {
+            "spec": spec_dir,
+            "config": config_dir,
+            "cwd": cwd,
+            "plain_file": str(spec_dir / "module.plain"),
+        }
+
+
+def test_default_log_file_name_resolves_next_to_spec(layout):
+    with patch("os.getcwd", return_value=str(layout["cwd"])):
+        args = parse_arguments([layout["plain_file"]])
+    assert args.log_file_name == str(layout["spec"] / DEFAULT_LOG_FILE_NAME)
+
+
+def test_cli_log_file_name_resolves_against_cwd(layout):
+    with patch("os.getcwd", return_value=str(layout["cwd"])):
+        args = parse_arguments([layout["plain_file"], "--log-file-name", "my.log"])
+    assert args.log_file_name == str(layout["cwd"] / "my.log")
+
+
+def test_config_log_file_name_resolves_against_config_dir(layout):
+    (layout["config"] / "config.yaml").write_text("log-file-name: from_config.log\n")
+    with patch("os.getcwd", return_value=str(layout["config"])):
+        args = parse_arguments([layout["plain_file"]])
+    assert args.log_file_name == str(layout["config"] / "from_config.log")
+
+
+def test_cli_absolute_log_file_name_preserved(layout):
+    abs_path = str(layout["spec"] / "abs.log")
+    with patch("os.getcwd", return_value=str(layout["cwd"])):
+        args = parse_arguments([layout["plain_file"], "--log-file-name", abs_path])
+    assert args.log_file_name == abs_path
+
+
+def test_log_file_name_with_no_log_to_file_errors_when_cli_supplied(layout, capsys):
+    with patch("os.getcwd", return_value=str(layout["cwd"])):
+        with pytest.raises(SystemExit):
+            parse_arguments([layout["plain_file"], "--log-file-name", "my.log", "--no-log-to-file"])
+    err = capsys.readouterr().err
+    assert "--log-file-name cannot be used when --log-to-file is False" in err
+
+
+def test_log_file_name_with_no_log_to_file_errors_when_config_supplied(layout, capsys):
+    """Config-supplied --log-file-name also counts as explicit."""
+    (layout["config"] / "config.yaml").write_text("log-file-name: from_config.log\n")
+    with patch("os.getcwd", return_value=str(layout["config"])):
+        with pytest.raises(SystemExit):
+            parse_arguments([layout["plain_file"], "--no-log-to-file"])
+    err = capsys.readouterr().err
+    assert "--log-file-name cannot be used when --log-to-file is False" in err
+
+
+def test_no_log_to_file_with_default_log_file_name_is_allowed(layout):
+    """When no explicit --log-file-name is given, --no-log-to-file is accepted."""
+    with patch("os.getcwd", return_value=str(layout["cwd"])):
+        args = parse_arguments([layout["plain_file"], "--no-log-to-file"])
+    assert args.log_to_file is False

--- a/tests/test_logging_config_path_resolution.py
+++ b/tests/test_logging_config_path_resolution.py
@@ -1,0 +1,67 @@
+"""Tests for --logging-config-path resolution.
+
+Same frame-of-reference rule as other path arguments: CLI values resolve
+against CWD, config.yaml values resolve against the config file's
+directory, and the default resolves against the spec file's directory.
+"""
+
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from plain2code_arguments import parse_arguments
+
+
+@pytest.fixture
+def layout():
+    """Three separate directories: spec dir, config dir, and CWD."""
+    with tempfile.TemporaryDirectory() as root:
+        spec_dir = Path(root) / "spec_dir"
+        config_dir = Path(root) / "config_dir"
+        cwd = Path(root) / "cwd"
+        spec_dir.mkdir()
+        config_dir.mkdir()
+        cwd.mkdir()
+        (spec_dir / "module.plain").write_text("")
+        yield {
+            "spec": spec_dir,
+            "config": config_dir,
+            "cwd": cwd,
+            "plain_file": str(spec_dir / "module.plain"),
+        }
+
+
+def test_default_logging_config_path_resolves_next_to_spec(layout):
+    with patch("os.getcwd", return_value=str(layout["cwd"])):
+        args = parse_arguments([layout["plain_file"]])
+    assert args.logging_config_path == str(layout["spec"] / "logging_config.yaml")
+
+
+def test_cli_logging_config_path_resolves_against_cwd(layout):
+    with patch("os.getcwd", return_value=str(layout["cwd"])):
+        args = parse_arguments([layout["plain_file"], "--logging-config-path", "custom_logging.yaml"])
+    assert args.logging_config_path == str(layout["cwd"] / "custom_logging.yaml")
+
+
+def test_config_logging_config_path_resolves_against_config_dir(layout):
+    (layout["config"] / "config.yaml").write_text("logging-config-path: logging_from_config.yaml\n")
+    with patch("os.getcwd", return_value=str(layout["config"])):
+        args = parse_arguments([layout["plain_file"]])
+    assert args.logging_config_path == str(layout["config"] / "logging_from_config.yaml")
+
+
+def test_cli_absolute_logging_config_path_preserved(layout):
+    abs_path = str(layout["spec"] / "abs_logging.yaml")
+    with patch("os.getcwd", return_value=str(layout["cwd"])):
+        args = parse_arguments([layout["plain_file"], "--logging-config-path", abs_path])
+    assert args.logging_config_path == abs_path
+
+
+def test_cli_overrides_config_with_cwd_anchor(layout):
+    (layout["config"] / "config.yaml").write_text("logging-config-path: from_config.yaml\n")
+    with patch("os.getcwd", return_value=str(layout["cwd"])):
+        args = parse_arguments([layout["plain_file"], "--logging-config-path", "from_cli.yaml"])
+    assert args.logging_config_path == str(layout["cwd"] / "from_cli.yaml")

--- a/tests/test_path_resolution.py
+++ b/tests/test_path_resolution.py
@@ -1,0 +1,65 @@
+import os
+
+import pytest
+
+from path_resolution import resolve_path
+
+CWD = "/work/cwd"
+CONFIG_DIR = "/work/project/config"
+SPEC_DIR = "/work/project/spec"
+
+
+def test_cli_relative_resolves_against_cwd():
+    result = resolve_path("out", "cli", cwd=CWD, config_dir=CONFIG_DIR, spec_dir=SPEC_DIR)
+    assert result == os.path.normpath("/work/cwd/out")
+
+
+def test_config_relative_resolves_against_config_dir():
+    result = resolve_path("out", "config", cwd=CWD, config_dir=CONFIG_DIR, spec_dir=SPEC_DIR)
+    assert result == os.path.normpath("/work/project/config/out")
+
+
+def test_default_relative_resolves_against_spec_dir():
+    result = resolve_path("out", "default", cwd=CWD, config_dir=CONFIG_DIR, spec_dir=SPEC_DIR)
+    assert result == os.path.normpath("/work/project/spec/out")
+
+
+def test_absolute_path_is_returned_unchanged_for_all_sources():
+    for source in ("cli", "config", "default"):
+        result = resolve_path("/abs/path", source, cwd=CWD, config_dir=CONFIG_DIR, spec_dir=SPEC_DIR)
+        assert result == os.path.normpath("/abs/path")
+
+
+def test_dotdot_segments_are_normalized():
+    result = resolve_path("../sibling", "cli", cwd=CWD, config_dir=CONFIG_DIR, spec_dir=SPEC_DIR)
+    assert result == os.path.normpath("/work/sibling")
+
+
+def test_leading_tilde_is_expanded(monkeypatch):
+    monkeypatch.setenv("HOME", "/home/alice")
+    result = resolve_path("~/scripts/run.sh", "cli", cwd=CWD, config_dir=CONFIG_DIR, spec_dir=SPEC_DIR)
+    assert result == os.path.normpath("/home/alice/scripts/run.sh")
+
+
+def test_tilde_expansion_applies_regardless_of_source(monkeypatch):
+    monkeypatch.setenv("HOME", "/home/alice")
+    for source in ("cli", "config", "default"):
+        result = resolve_path("~/x", source, cwd=CWD, config_dir=CONFIG_DIR, spec_dir=SPEC_DIR)
+        assert result == os.path.normpath("/home/alice/x")
+
+
+def test_config_source_requires_config_dir():
+    with pytest.raises(ValueError, match="config_dir"):
+        resolve_path("out", "config", cwd=CWD, config_dir=None, spec_dir=SPEC_DIR)
+
+
+def test_config_dir_may_be_none_for_cli_and_default():
+    cli_result = resolve_path("out", "cli", cwd=CWD, config_dir=None, spec_dir=SPEC_DIR)
+    default_result = resolve_path("out", "default", cwd=CWD, config_dir=None, spec_dir=SPEC_DIR)
+    assert cli_result == os.path.normpath("/work/cwd/out")
+    assert default_result == os.path.normpath("/work/project/spec/out")
+
+
+def test_unknown_source_raises():
+    with pytest.raises(ValueError, match="Unknown path source"):
+        resolve_path("out", "bogus", cwd=CWD, config_dir=CONFIG_DIR, spec_dir=SPEC_DIR)  # type: ignore[arg-type]

--- a/tests/test_script_path_resolution.py
+++ b/tests/test_script_path_resolution.py
@@ -1,0 +1,107 @@
+"""Tests for script-path argument resolution.
+
+Covers the rule that the resolution base for a relative script path is
+determined by where the value was written -- CWD for CLI, config-file
+directory for config.yaml values.
+"""
+
+import os
+import stat
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from plain2code_arguments import parse_arguments
+
+
+def _make_script(path: Path) -> None:
+    path.write_text("#!/bin/sh\necho hello\n")
+    path.chmod(path.stat().st_mode | stat.S_IEXEC)
+
+
+@pytest.fixture
+def layout():
+    """Project layout with separate dirs for spec, config, and CWD, each with a script."""
+    with tempfile.TemporaryDirectory() as root:
+        spec_dir = Path(root) / "spec_dir"
+        config_dir = Path(root) / "config_dir"
+        cwd = Path(root) / "cwd"
+        spec_dir.mkdir()
+        config_dir.mkdir()
+        cwd.mkdir()
+
+        (spec_dir / "module.plain").write_text("")
+        _make_script(spec_dir / "script_in_spec.sh")
+        _make_script(config_dir / "script_in_config.sh")
+        _make_script(cwd / "script_in_cwd.sh")
+
+        yield {
+            "spec": spec_dir,
+            "config": config_dir,
+            "cwd": cwd,
+            "plain_file": str(spec_dir / "module.plain"),
+        }
+
+
+def test_cli_script_path_resolves_against_cwd(layout):
+    with patch("os.getcwd", return_value=str(layout["cwd"])):
+        args = parse_arguments([layout["plain_file"], "--unittests-script", "script_in_cwd.sh"])
+    assert args.unittests_script == str(layout["cwd"] / "script_in_cwd.sh")
+
+
+def test_config_script_path_resolves_against_config_dir(layout):
+    (layout["config"] / "config.yaml").write_text("unittests-script: script_in_config.sh\n")
+
+    with patch("os.getcwd", return_value=str(layout["config"])):
+        args = parse_arguments([layout["plain_file"]])
+
+    assert args.unittests_script == str(layout["config"] / "script_in_config.sh")
+
+
+def test_cli_script_path_does_not_fall_back_to_config_dir(layout):
+    """A CLI value that happens to match a file in the config dir must NOT resolve there."""
+    (layout["config"] / "config.yaml").write_text("verbose: true\n")
+
+    with patch("os.getcwd", return_value=str(layout["cwd"])):
+        with pytest.raises(FileNotFoundError, match="unittests_script"):
+            # script_in_config.sh does not exist relative to CWD, so resolution must fail
+            parse_arguments([layout["plain_file"], "--unittests-script", "script_in_config.sh"])
+
+
+def test_cli_script_with_dotdot_resolves_against_cwd(layout):
+    """Tab-completion-style relative path like ../config_dir/script.sh works from CWD."""
+    with patch("os.getcwd", return_value=str(layout["cwd"])):
+        args = parse_arguments([layout["plain_file"], "--unittests-script", "../config_dir/script_in_config.sh"])
+    assert args.unittests_script == str(layout["config"] / "script_in_config.sh")
+
+
+def test_absolute_script_path_preserved(layout):
+    abs_path = str(layout["spec"] / "script_in_spec.sh")
+    with patch("os.getcwd", return_value=str(layout["cwd"])):
+        args = parse_arguments([layout["plain_file"], "--unittests-script", abs_path])
+    assert args.unittests_script == abs_path
+
+
+def test_missing_script_raises(layout):
+    with patch("os.getcwd", return_value=str(layout["cwd"])):
+        with pytest.raises(FileNotFoundError):
+            parse_arguments([layout["plain_file"], "--unittests-script", "nope.sh"])
+
+
+def test_all_three_script_args_resolved(layout):
+    """unittests-script, conformance-tests-script, prepare-environment-script all go through the same path."""
+    (layout["config"] / "config.yaml").write_text(
+        "unittests-script: script_in_config.sh\n"
+        "conformance-tests-script: script_in_config.sh\n"
+        "prepare-environment-script: script_in_config.sh\n"
+    )
+
+    with patch("os.getcwd", return_value=str(layout["config"])):
+        args = parse_arguments([layout["plain_file"]])
+
+    expected = str(layout["config"] / "script_in_config.sh")
+    assert args.unittests_script == expected
+    assert args.conformance_tests_script == expected
+    assert args.prepare_environment_script == expected


### PR DESCRIPTION
This makes change to how we resolve path parameters (e.g.: build_folder, log_file_name, conformance_tests_folder).

The main change to the user is that now the parameter path is resolved based on where the parameter was provided:
config.yaml, CLI argument. If parameter is not provided in either of those, the parameter's default value will be relative to the spec file.

Until now some parameters were relative to the config file even if provided as CLI argument (e.g.: `conformance-tests-script`, `log-file-name` ...).