### PR TITLE
Fix memory creation triggering across different modules with same frid

### DIFF
--- a/memory_management.py
+++ b/memory_management.py
@@ -33,8 +33,14 @@ class MemoryManager:
     ):
 
         current_conformance_tests_issue_frid = render_context.conformance_tests_running_context.current_testing_frid
+        current_conformance_tests_issue_module = (
+            render_context.conformance_tests_running_context.current_testing_module_name
+        )
         old_conformance_tests_issue_frid = (
             render_context.conformance_tests_running_context.previous_conformance_tests_issue_frid
+        )
+        old_conformance_tests_issue_module = (
+            render_context.conformance_tests_running_context.previous_conformance_tests_issue_module
         )
 
         old_conformance_tests_issue = (
@@ -42,9 +48,14 @@ class MemoryManager:
         )
 
         is_first_time_running_conformance_tests = (
-            old_conformance_tests_issue_frid is None or old_conformance_tests_issue_frid == ""
+            old_conformance_tests_issue_frid is None
+            or old_conformance_tests_issue_frid == ""
+            or old_conformance_tests_issue_module != current_conformance_tests_issue_module
         )
-        is_same_frid_as_previous_failing_test = current_conformance_tests_issue_frid == old_conformance_tests_issue_frid
+        is_same_frid_as_previous_failing_test = (
+            current_conformance_tests_issue_frid == old_conformance_tests_issue_frid
+            and current_conformance_tests_issue_module == old_conformance_tests_issue_module
+        )
         is_conformance_test_failed = exit_code != CONFORMANCE_TESTS_SUCCESS_EXIT_CODE
 
         should_create_memory = not is_first_time_running_conformance_tests and (

--- a/render_machine/actions/fix_conformance_test.py
+++ b/render_machine/actions/fix_conformance_test.py
@@ -30,6 +30,9 @@ class FixConformanceTest(BaseAction):
         render_context.conformance_tests_running_context.previous_conformance_tests_issue_frid = (
             render_context.conformance_tests_running_context.current_testing_frid
         )
+        render_context.conformance_tests_running_context.previous_conformance_tests_issue_module = (
+            render_context.conformance_tests_running_context.current_testing_module_name
+        )
 
         if render_context.conformance_tests_running_context.current_testing_frid == render_context.frid_context.frid:
             console_message = f"Fixing conformance test for functionality {render_context.conformance_tests_running_context.current_testing_frid} in module {render_context.conformance_tests_running_context.current_testing_module_name}."

--- a/render_machine/render_types.py
+++ b/render_machine/render_types.py
@@ -49,6 +49,7 @@ class ConformanceTestsRunningContext:
         self.current_testing_frid_high_level_implementation_plan: Optional[str] = None
         self.previous_conformance_tests_issue_old: Optional[str] = None
         self.previous_conformance_tests_issue_frid: Optional[str] = None
+        self.previous_conformance_tests_issue_module: Optional[str] = None
         self.code_diff_files: Optional[dict[str, str]] = None
 
     def get_conformance_tests_json(self, module_name: str) -> dict:


### PR DESCRIPTION
Memory creation guard conditions compared only frid, not frid+module, causing create_conformance_test_memory to fire on the first failure of a new (module, frid) pair using stale code_diff from a previous module.