### PR TITLE
Allow requiring modules in subdirectories.

### DIFF
--- a/plain_file.py
+++ b/plain_file.py
@@ -629,7 +629,11 @@ def plain_file_parser(  # noqa: C901
             f"Invalid plain file extension: {plain_source_file_path.suffix}. Expected: {PLAIN_SOURCE_FILE_EXTENSION}."
         )
 
-    module_name = plain_source_file_path.stem
+    module_name = (
+        plain_source_file_path.stem
+        if plain_source_file_path.is_absolute()
+        else plain_source_file_path.with_suffix("").as_posix()
+    )
 
     code_variables = {}
 


### PR DESCRIPTION
https://github.com/Codeplain-ai/next-microsoft/issues/53

This fixes the problem where the user couldn't do:
```
requires: shared/server
```
The tool would print `Module does not exist (server)` and fail.

By using `.with_suffix("")` instead of `.stem()` the subdirectories are kept in case of relative paths.