### PR TITLE
remove 'testing status' widget if test scripts not provided

### DIFF
--- a/tui/plain2code_tui.py
+++ b/tui/plain2code_tui.py
@@ -28,7 +28,6 @@ from .components import (
     LogLevelFilter,
     ProgressItem,
     RenderingInfoBox,
-    ScriptOutputType,
     StructuredLogView,
     TestScriptsContainer,
     TUIComponents,
@@ -109,21 +108,6 @@ class Plain2CodeTUI(App):
             self, self.unittests_script, self.conformance_tests_script
         )
 
-    def get_active_script_types(self) -> list[ScriptOutputType]:
-        """Get the list of active script output types based on which scripts exist.
-
-        Returns:
-            List of ScriptOutputType enum members for scripts that are configured
-        """
-        active_types = []
-        if self.unittests_script is not None:
-            active_types.append(ScriptOutputType.UNIT_TEST_OUTPUT_TEXT)
-        if self.conformance_tests_script is not None:
-            active_types.append(ScriptOutputType.CONFORMANCE_TEST_OUTPUT_TEXT)
-        if self.prepare_environment_script is not None:
-            active_types.append(ScriptOutputType.TESTING_ENVIRONMENT_OUTPUT_TEXT)
-        return active_types
-
     def on_mount(self) -> None:
         """Called when the app is mounted."""
         self.event_bus.subscribe(RenderStateUpdated, self.on_render_state_updated)
@@ -153,12 +137,17 @@ class Plain2CodeTUI(App):
                     )
 
                     # Test scripts container with border
-                    yield TestScriptsContainer(
-                        id=TUIComponents.TEST_SCRIPTS_CONTAINER.value,
-                        show_unit_test=self.unittests_script is not None,
-                        show_conformance_test=self.conformance_tests_script is not None,
-                        show_testing_env=self.prepare_environment_script is not None,
-                    )
+                    if (
+                        self.unittests_script is not None
+                        or self.conformance_tests_script is not None
+                        or self.prepare_environment_script is not None
+                    ):
+                        yield TestScriptsContainer(
+                            id=TUIComponents.TEST_SCRIPTS_CONTAINER.value,
+                            show_unit_test=self.unittests_script is not None,
+                            show_conformance_test=self.conformance_tests_script is not None,
+                            show_testing_env=self.prepare_environment_script is not None,
+                        )
                     yield Static(
                         "[#FFFFFF]Rendering in progress...[/#FFFFFF]",
                         id=TUIComponents.RENDER_STATUS_WIDGET.value,

--- a/tui/styles.css
+++ b/tui/styles.css
@@ -42,6 +42,7 @@ We might need those at some point, so just commenting them out for now.
 }
 
 #render-status-widget {
+  margin-top: 1;
   height: auto;
 }
 
@@ -137,7 +138,7 @@ TestScriptsContainer {
   height: auto;
   color: #888;
   border: solid #888;
-  padding: 0 1;
+  padding-top: 1;
 }
 
 .test-scripts-title {


### PR DESCRIPTION
Based on @zanjonke's comment here: https://github.com/Codeplain-ai/next-microsoft/issues/62

This removes the "testing status" widget or section of the TUI if the user doesn't provide any test scripts.

Example:
<img width="613" height="337" alt="image" src="https://github.com/user-attachments/assets/5734a9fe-6ed9-44fb-b78c-272481dfd9f7" />
