### PR TITLE
Setting --copy-build parameter to True by default.

### DIFF
--- a/plain2code_arguments.py
+++ b/plain2code_arguments.py
@@ -302,7 +302,7 @@ def create_parser():
     parser.add_argument(
         "--copy-build",
         action="store_true",
-        default=False,
+        default=True,
         help="If set, copy the rendered contents of code in `--base-folder` folder to `--build-dest` folder after successful rendering.",
     )
     parser.add_argument(


### PR DESCRIPTION
With the new structure of modules (/plain_modules) it is not easy to see what is the final generated code. In plainlang_examples we've solved this by explicitly setting --copy-build parameter to True. But this feels like it should be default behavior and only turned off explicitly if required by the user.