### PR TITLE
Fix the TUI and the post render console output for failed renders

### DIFF
--- a/plain2code.py
+++ b/plain2code.py
@@ -233,12 +233,10 @@ def render(args, run_state: RunState, event_bus: EventBus):  # noqa: C901
     )
 
     render_error: list[Exception] = []
-    run_state.render_succeeded = False
 
     def run_render():
         try:
             module_renderer.render_module()
-            run_state.set_render_succeeded(True)
         except RenderCancelledError:
             pass  # TUI already closed, nothing to report
         except Exception as e:
@@ -250,7 +248,6 @@ def render(args, run_state: RunState, event_bus: EventBus):  # noqa: C901
         console.info(f"Render started. Render ID: {run_state.render_id}")
         try:
             module_renderer.render_module()
-            run_state.set_render_succeeded(True)
         except RenderCancelledError:
             run_state.set_render_succeeded(False)
             pass

--- a/plain2code_events.py
+++ b/plain2code_events.py
@@ -55,7 +55,12 @@ class RenderStateUpdated(BaseEvent):
 
 @dataclass
 class RenderModuleCompleted(BaseEvent):
-    pass
+    module_name: str
+
+
+@dataclass
+class RenderModuleFailed(BaseEvent):
+    module_name: str
 
 
 @dataclass

--- a/render_machine/code_renderer.py
+++ b/render_machine/code_renderer.py
@@ -3,7 +3,13 @@ from copy import deepcopy
 
 from transitions.extensions.diagrams import HierarchicalGraphMachine
 
-from plain2code_events import RenderModuleCompleted, RenderModuleStarted, RenderPaused, RenderStateUpdated
+from plain2code_events import (
+    RenderModuleCompleted,
+    RenderModuleFailed,
+    RenderModuleStarted,
+    RenderPaused,
+    RenderStateUpdated,
+)
 from render_machine.render_context import RenderContext
 from render_machine.state_machine_config import StateMachineConfig, States
 
@@ -59,16 +65,21 @@ class CodeRenderer:
             previous_state = deepcopy(self.render_context.state)
             self.render_context.script_execution_history.should_update_script_outputs = False
 
+            self.render_context.previous_action_payload = previous_action_payload
+
             outcome, previous_action_payload = self.action_map[self.render_context.state].execute(
                 self.render_context, previous_action_payload
             )
-            self.render_context.previous_action_payload = previous_action_payload
 
-            if self.render_context.state in [
-                States.RENDER_FAILED.value,
-                States.RENDER_COMPLETED.value,
-            ]:
-                self.render_context.event_bus.publish(RenderModuleCompleted())
+            if self.render_context.state == States.RENDER_FAILED.value:
+                self.render_context.last_error_message = previous_action_payload
+                self.render_context.event_bus.publish(RenderModuleFailed(module_name=self.render_context.module_name))
+                break
+
+            if self.render_context.state == States.RENDER_COMPLETED.value:
+                self.render_context.event_bus.publish(
+                    RenderModuleCompleted(module_name=self.render_context.module_name)
+                )
                 break
 
             next_trigger = self.action_result_triggers_map[outcome]

--- a/tui/components.py
+++ b/tui/components.py
@@ -134,6 +134,10 @@ class SubstateLine(Horizontal):
         else:
             self._timer.resume()
 
+    def stop_progress_timer(self) -> None:
+        if self._timer is not None:
+            self._timer.stop()
+
     def _add_second(self) -> None:
         self._seconds_elapsed += 1
         self._refresh_timer()

--- a/tui/plain2code_tui.py
+++ b/tui/plain2code_tui.py
@@ -14,12 +14,13 @@ from plain2code_events import (
     RenderContextSnapshot,
     RenderFailed,
     RenderModuleCompleted,
+    RenderModuleFailed,
     RenderModuleStarted,
     RenderPaused,
     RenderStateUpdated,
 )
 from render_machine.states import States
-from tui.widget_helpers import log_to_widget, transition_frid_progress
+from tui.widget_helpers import display_module_name, log_to_widget, stop_progress_timer, transition_frid_progress
 
 from .components import (
     CustomFooter,
@@ -131,6 +132,7 @@ class Plain2CodeTUI(App):
         self.event_bus.subscribe(RenderFailed, self.on_render_failed)
         self.event_bus.subscribe(RenderModuleStarted, self.on_render_module_started)
         self.event_bus.subscribe(RenderModuleCompleted, self.on_render_module_completed)
+        self.event_bus.subscribe(RenderModuleFailed, self.on_render_module_failed)
         self.event_bus.subscribe(LogMessageEmitted, self.on_log_message_emitted)
         self.event_bus.subscribe(RenderPaused, self.on_render_paused)
 
@@ -186,14 +188,14 @@ class Plain2CodeTUI(App):
         except Exception as e:
             log_to_widget(self, "WARNING", f"Error updating render module name: {type(e).__name__}: {e}")
 
-    def on_render_module_completed(self, _event: RenderModuleCompleted):
+    def on_render_module_completed(self, event: RenderModuleCompleted):
         """Update TUI based on the current state machine state."""
-        try:
-            frid_progress = self.query_one(f"#{TUIComponents.FRID_PROGRESS.value}", FRIDProgress)
-            info_box = frid_progress.query_one(RenderingInfoBox)
-            info_box.update_module(FRIDProgress.RENDERING_MODULE_TEXT)
-        except Exception as e:
-            log_to_widget(self, "WARNING", f"Error resetting render module name: {type(e).__name__}: {e}")
+        display_module_name(self, event.module_name)
+
+    def on_render_module_failed(self, event: RenderModuleFailed):
+        """Update TUI based on the current state machine state."""
+        display_module_name(self, event.module_name)
+        stop_progress_timer(self)
 
     def on_log_message_emitted(self, event: LogMessageEmitted):
         try:

--- a/tui/widget_helpers.py
+++ b/tui/widget_helpers.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from textual.css.query import NoMatches
 from textual.widgets import Static
 
-from .components import FRIDProgress, ProgressItem, StructuredLogView, TUIComponents
+from .components import FRIDProgress, ProgressItem, RenderingInfoBox, StructuredLogView, SubstateLine, TUIComponents
 from .models import Substate
 
 
@@ -167,3 +167,26 @@ def clear_progress_item_substates(tui, widget_id: str) -> None:
         log_to_widget(tui, "WARNING", f"ProgressItem {widget_id} not found: {e}")
     except Exception as e:
         log_to_widget(tui, "ERROR", f"Error clearing substates for {widget_id}: {e}")
+
+
+def display_module_name(tui, module_name: str):
+    """Helper function to display the module name in the FRIDProgress widget.
+
+    Args:
+        tui: The Plain2CodeTUI instance
+        module_name: The module name to display
+    """
+    frid_progress = get_frid_progress(tui)
+    info_box = frid_progress.query_one(RenderingInfoBox)
+    info_box.update_module(f"{FRIDProgress.RENDERING_MODULE_TEXT}{module_name}")
+
+
+def stop_progress_timer(tui):
+    """Helper function to stop the progress timer in the FRIDProgress widget.
+
+    Args:
+        tui: The Plain2CodeTUI instance
+    """
+    frid_progress = get_frid_progress(tui)
+    substate_line = frid_progress.query_one(SubstateLine)
+    substate_line.stop_progress_timer()


### PR DESCRIPTION
https://github.com/Codeplain-ai/next-microsoft/issues/62

What this PR does:
1. it adds the missing module name when render fails or completes
2. it stops the timer when rendering fails
3. fixes the error output (displays the actual error message instead of the fallback "Unknown error")
4. the console output after rendering was also broken - it said "✓ rendering completed" instead of "✗ rendering failed" when failed

<img width="770" height="326" alt="582738097-f0318ebe-0e4a-400a-842f-492fc96cdb5e" src="https://github.com/user-attachments/assets/7e6ac54f-826a-47f0-b83d-3d7ff1ea304a" />
