### PR TITLE
Raise clear error when plain file references a binary resource

### DIFF
--- a/file_utils.py
+++ b/file_utils.py
@@ -8,6 +8,7 @@ from liquid2.exceptions import UndefinedError
 
 import plain_spec
 from plain2code_console import console
+from plain2code_exceptions import UnsupportedResourceType
 from plain2code_nodes import Plain2CodeIncludeTag, Plain2CodeLoaderMixin
 from plain_modules import CODEPLAIN_MEMORY_SUBFOLDER, CODEPLAIN_METADATA_FOLDER
 
@@ -217,13 +218,7 @@ def open_from(dirs, file_name):
 
         with open(full_file_name, "rb") as f:
             content = f.read()
-            try:
-                content_text = content.decode("utf-8")
-            except UnicodeDecodeError:
-                console.debug(
-                    f"WARNING! Error loading {file_name} ({file_name}). File is not a text file. Skipping it."
-                )
-            return content_text
+        return content.decode("utf-8")
 
     return None
 
@@ -236,7 +231,13 @@ def load_linked_resources(template_dirs: list[str], resources_list):
         if file_name in linked_resources:
             continue
 
-        content = open_from(template_dirs, file_name)
+        try:
+            content = open_from(template_dirs, file_name)
+        except UnicodeDecodeError:
+            raise UnsupportedResourceType(
+                f"Referenced resource '{file_name}' is a binary file. "
+                f"Only text files (e.g. .md, .txt, .json, .yaml) can be referenced from a .plain file."
+            )
 
         if content is None:
             raise FileNotFoundError(f"""File not found:

--- a/file_utils.py
+++ b/file_utils.py
@@ -223,7 +223,7 @@ def open_from(dirs, file_name):
     return None
 
 
-def load_linked_resources(template_dirs: list[str], resources_list):
+def load_linked_resources(template_dirs: list[str], resources_list, module_name: str):
     linked_resources = {}
 
     for resource in resources_list:
@@ -235,7 +235,7 @@ def load_linked_resources(template_dirs: list[str], resources_list):
             content = open_from(template_dirs, file_name)
         except UnicodeDecodeError:
             raise UnsupportedResourceType(
-                f"Referenced resource '{file_name}' is a binary file. "
+                f"Referenced resource '{file_name}' in module '{module_name}' is a binary file. "
                 f"Only text files (e.g. .md, .txt, .json, .yaml) can be referenced from a .plain file."
             )
 

--- a/plain2code.py
+++ b/plain2code.py
@@ -33,6 +33,7 @@ from plain2code_exceptions import (
     PlainSyntaxError,
     RenderCancelledError,
     RenderingCreditBalanceTooLow,
+    UnsupportedResourceType,
 )
 from plain2code_logger import (
     LOGGER_NAME,
@@ -350,6 +351,7 @@ def main():  # noqa: C901
                     RenderingCreditBalanceTooLow,
                     NetworkConnectionError,
                     ModuleDoesNotExistError,
+                    UnsupportedResourceType,
                 ),
             ):
                 exc_info = sys.exc_info()

--- a/plain2code_exceptions.py
+++ b/plain2code_exceptions.py
@@ -21,6 +21,10 @@ class MissingResource(Exception):
     pass
 
 
+class UnsupportedResourceType(Exception):
+    pass
+
+
 class PlainSyntaxError(Exception):
     pass
 

--- a/render_machine/render_context.py
+++ b/render_machine/render_context.py
@@ -85,7 +85,7 @@ class RenderContext:
 
         resources_list = []
         plain_spec.collect_linked_resources(plain_source_tree, resources_list, None, True)
-        self.all_linked_resources = file_utils.load_linked_resources(template_dirs, resources_list)
+        self.all_linked_resources = file_utils.load_linked_resources(template_dirs, resources_list, module_name)
 
         # Initialize context objects
         self.frid_context: Optional[FridContext] = None

--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -1,0 +1,40 @@
+import os
+import tempfile
+
+import pytest
+
+from file_utils import load_linked_resources
+from plain2code_exceptions import UnsupportedResourceType
+
+
+@pytest.fixture
+def template_dir():
+    with tempfile.TemporaryDirectory() as d:
+        yield d
+
+
+def test_load_linked_resources_text_file(template_dir):
+    file_path = os.path.join(template_dir, "notes.md")
+    with open(file_path, "w") as f:
+        f.write("# hello")
+
+    result = load_linked_resources([template_dir], [{"text": "Notes", "target": "notes.md"}])
+
+    assert result == {"notes.md": "# hello"}
+
+
+def test_load_linked_resources_binary_file_raises_unsupported_resource_type(template_dir):
+    file_path = os.path.join(template_dir, "icon.png")
+    with open(file_path, "wb") as f:
+        f.write(b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\xff\xfe\xfd")
+
+    with pytest.raises(UnsupportedResourceType) as exc_info:
+        load_linked_resources([template_dir], [{"text": "Icon", "target": "icon.png"}])
+
+    assert "icon.png" in str(exc_info.value)
+    assert "binary file" in str(exc_info.value)
+
+
+def test_load_linked_resources_missing_file_raises_file_not_found(template_dir):
+    with pytest.raises(FileNotFoundError):
+        load_linked_resources([template_dir], [{"text": "Missing", "target": "missing.md"}])

--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -18,7 +18,7 @@ def test_load_linked_resources_text_file(template_dir):
     with open(file_path, "w") as f:
         f.write("# hello")
 
-    result = load_linked_resources([template_dir], [{"text": "Notes", "target": "notes.md"}])
+    result = load_linked_resources([template_dir], [{"text": "Notes", "target": "notes.md"}], "my_thing")
 
     assert result == {"notes.md": "# hello"}
 
@@ -29,12 +29,13 @@ def test_load_linked_resources_binary_file_raises_unsupported_resource_type(temp
         f.write(b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\xff\xfe\xfd")
 
     with pytest.raises(UnsupportedResourceType) as exc_info:
-        load_linked_resources([template_dir], [{"text": "Icon", "target": "icon.png"}])
+        load_linked_resources([template_dir], [{"text": "Icon", "target": "icon.png"}], "my_thing")
 
     assert "icon.png" in str(exc_info.value)
     assert "binary file" in str(exc_info.value)
+    assert "my_thing" in str(exc_info.value)
 
 
 def test_load_linked_resources_missing_file_raises_file_not_found(template_dir):
     with pytest.raises(FileNotFoundError):
-        load_linked_resources([template_dir], [{"text": "Missing", "target": "missing.md"}])
+        load_linked_resources([template_dir], [{"text": "Missing", "target": "missing.md"}], "my_thing")


### PR DESCRIPTION
Referencing a binary file from a .plain file crashed with "cannot access local variable 'content_text' where it is not associated with a value" because open_from() swallowed UnicodeDecodeError but still returned the never-assigned variable.

After this PR, the reference to any binary file should be reported as UnsupportedResourceType.