### PR TITLE
default --verbose to true

### DIFF
--- a/plain2code_arguments.py
+++ b/plain2code_arguments.py
@@ -175,7 +175,9 @@ def create_parser():
         help="Path to the plain file to render. The directory containing this file has highest precedence for template loading, "
         "so you can place custom templates here to override the defaults. See --template-dir for more details about template loading.",
     )
-    parser.add_argument("--verbose", "-v", action="store_true", help="Enable verbose output")
+    parser.add_argument(
+        "--verbose", "-v", action="store_true", default=True, help="Enable verbose output (default: enabled)"
+    )
     parser.add_argument("--base-folder", type=str, help="Base folder for the build files")
     parser.add_argument(
         "--build-folder", type=non_empty_string, default=DEFAULT_BUILD_FOLDER, help="Folder for build files"


### PR DESCRIPTION
This makes verbose output enabled by default so that the TUI always receives script output paths (which are gated on verbose inside execute_script). Without this, --verbose had to be explicitly passed for the testing-status panel to show paths to unit-test, conformance-test and prepare-environment outputs.

The --verbose / -v flag is retained for backward compatibility but is now effectively a no-op.

The --verbose flag should be reconsidered in the future — is it even needed at all, or should verbose behavior be unconditional and the flag removed entirely?