### PR TITLE
E2E test for Codeplain installation and rendering Hello World!

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,62 @@
+# .github/workflows/e2e.yml
+name: E2E
+
+on:
+  schedule:
+    - cron: '0 5 * * 1-5'   # weekday nights to catch API drift
+  workflow_dispatch:
+
+jobs:
+  e2e-linux:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - run: pip install pytest
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build E2E image (cached)
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: tests/e2e/Dockerfile
+          tags: codeplain-e2e:latest
+          load: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Run E2E tests
+        env:
+          CODEPLAIN_API_KEY: ${{ secrets.CODEPLAIN_API_KEY }}
+        run: pytest tests/e2e/ -v --tb=short
+
+      - name: Upload generated outputs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-outputs-linux
+          path: /tmp/pytest-of-runner/**/container_work*/**
+
+  e2e-windows:
+    runs-on: windows-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - run: pip install pytest
+
+      - name: Run E2E tests
+        env:
+          CODEPLAIN_API_KEY: ${{ secrets.CODEPLAIN_API_KEY }}
+        run: pytest tests/e2e/ -v --tb=short

--- a/install/bash/install.sh
+++ b/install/bash/install.sh
@@ -22,7 +22,13 @@ NC='\033[0m' # No Color / Reset
 # Export colors for child scripts
 export YELLOW GREEN GREEN_LIGHT GREEN_DARK BLUE BLACK WHITE RED GRAY GRAY_LIGHT BOLD NC
 
-clear
+NONINTERACTIVE="${CODEPLAIN_INSTALL_NONINTERACTIVE:-0}"
+
+if [ "$NONINTERACTIVE" = "1" ]; then
+    echo "running in non-interactive mode (CODEPLAIN_INSTALL_NONINTERACTIVE=1)"
+else
+    clear
+fi
 echo -e "started ${YELLOW}${BOLD}*codeplain CLI${NC} installation..."
 
 # Install uv if not present
@@ -61,31 +67,42 @@ else
     echo -e "installing codeplain...${NC}"
     echo -e ""
     uv tool install codeplain
-    clear
+    if [ "$NONINTERACTIVE" != "1" ]; then
+        clear
+    fi
     echo -e "${GREEN}✓ codeplain installed successfully!${NC}"
 fi
 
 # Check if API key already exists
 SKIP_API_KEY_SETUP=false
 if [ -n "${CODEPLAIN_API_KEY:-}" ]; then
-    echo -e "  you already have an API key configured."
-    echo ""
-    echo -e "  would you like to log in and get a new one?"
-    echo ""
-    read -r -p "  [y/N]: " GET_NEW_KEY < /dev/tty
-    echo ""
-
-    if [[ ! "$GET_NEW_KEY" =~ ^[Yy]$ ]]; then
-        echo -e "${GREEN}✓${NC} using existing API key."
+    if [ "$NONINTERACTIVE" = "1" ]; then
+        echo -e "${GREEN}✓${NC} using existing CODEPLAIN_API_KEY (non-interactive mode)."
         SKIP_API_KEY_SETUP=true
+    else
+        echo -e "  you already have an API key configured."
+        echo ""
+        echo -e "  would you like to log in and get a new one?"
+        echo ""
+        read -r -p "  [y/N]: " GET_NEW_KEY < /dev/tty
+        echo ""
+
+        if [[ ! "$GET_NEW_KEY" =~ ^[Yy]$ ]]; then
+            echo -e "${GREEN}✓${NC} using existing API key."
+            SKIP_API_KEY_SETUP=true
+        fi
     fi
 fi
 
 if [ "$SKIP_API_KEY_SETUP" = false ]; then
-    echo -e "go to ${YELLOW}https://platform.codeplain.ai${NC} and sign up to get your API key."
-    echo ""
-    read -r -p "paste your API key here: " API_KEY < /dev/tty
-    echo ""
+    if [ "$NONINTERACTIVE" = "1" ]; then
+        echo -e "${GRAY}no CODEPLAIN_API_KEY set; skipping key setup (non-interactive mode).${NC}"
+    else
+        echo -e "go to ${YELLOW}https://platform.codeplain.ai${NC} and sign up to get your API key."
+        echo ""
+        read -r -p "paste your API key here: " API_KEY < /dev/tty
+        echo ""
+    fi
 fi
 
 if [ "$SKIP_API_KEY_SETUP" = true ]; then
@@ -130,7 +147,9 @@ else
 fi
 
 # ASCII Art Welcome
-clear
+if [ "$NONINTERACTIVE" != "1" ]; then
+    clear
+fi
 echo ""
 echo -e "${NC}"
 echo -e "${GRAY}────────────────────────────────────────────${NC}"
@@ -153,10 +172,14 @@ echo ""
 echo ""
 echo -e "${GRAY}────────────────────────────────────────────${NC}"
 echo ""
-echo -e "  would you like to get a quick intro to ***plain specification language?"
-echo ""
-read -r -p "  [Y/n]: " WALKTHROUGH_CHOICE < /dev/tty
-echo ""
+if [ "$NONINTERACTIVE" = "1" ]; then
+    WALKTHROUGH_CHOICE="n"
+else
+    echo -e "  would you like to get a quick intro to ***plain specification language?"
+    echo ""
+    read -r -p "  [Y/n]: " WALKTHROUGH_CHOICE < /dev/tty
+    echo ""
+fi
 
 # Determine script directory for local execution
 SCRIPT_DIR=""
@@ -193,19 +216,23 @@ if [[ ! "$WALKTHROUGH_CHOICE" =~ ^[Nn]$ ]]; then
 fi
 
 # Download examples step
-clear
-echo ""
-echo -e "${GRAY}────────────────────────────────────────────${NC}"
-echo -e "  ${YELLOW}${BOLD}Example Projects${NC}"
-echo -e "${GRAY}────────────────────────────────────────────${NC}"
-echo ""
-echo -e "  we've prepared some example Plain projects for you"
-echo -e "  to explore and experiment with."
-echo ""
-echo -e "  would you like to download them?"
-echo ""
-read -r -p "  [Y/n]: " DOWNLOAD_EXAMPLES < /dev/tty
-echo ""
+if [ "$NONINTERACTIVE" = "1" ]; then
+    DOWNLOAD_EXAMPLES="n"
+else
+    clear
+    echo ""
+    echo -e "${GRAY}────────────────────────────────────────────${NC}"
+    echo -e "  ${YELLOW}${BOLD}Example Projects${NC}"
+    echo -e "${GRAY}────────────────────────────────────────────${NC}"
+    echo ""
+    echo -e "  we've prepared some example Plain projects for you"
+    echo -e "  to explore and experiment with."
+    echo ""
+    echo -e "  would you like to download them?"
+    echo ""
+    read -r -p "  [Y/n]: " DOWNLOAD_EXAMPLES < /dev/tty
+    echo ""
+fi
 
 # Run examples download if user agrees
 if [[ ! "${DOWNLOAD_EXAMPLES:-}" =~ ^[Nn]$ ]]; then
@@ -213,7 +240,9 @@ if [[ ! "${DOWNLOAD_EXAMPLES:-}" =~ ^[Nn]$ ]]; then
 fi
 
 # Final message
-clear
+if [ "$NONINTERACTIVE" != "1" ]; then
+    clear
+fi
 echo ""
 echo -e "${GRAY}────────────────────────────────────────────${NC}"
 echo -e "  ${YELLOW}${BOLD}You're all set!${NC}"
@@ -230,6 +259,8 @@ echo ""
 echo -e "  ${GREEN}happy development!${NC} 🚀"
 echo ""
 
-# Replace this subshell with a fresh shell that has the new environment
-# Reconnect stdin to terminal (needed when running via curl | bash)
-exec "$SHELL" < /dev/tty
+if [ "$NONINTERACTIVE" != "1" ]; then
+    # Replace this subshell with a fresh shell that has the new environment
+    # Reconnect stdin to terminal (needed when running via curl | bash)
+    exec "$SHELL" < /dev/tty
+fi

--- a/install/powershell/install.ps1
+++ b/install/powershell/install.ps1
@@ -1,5 +1,12 @@
 $ErrorActionPreference = 'Stop'
 
+# Non-interactive mode for unattended installs (CI, scripted setup). Skips all
+# prompts and Clear-Host calls. Same env var name as install.sh.
+$nonInteractive = ($env:CODEPLAIN_INSTALL_NONINTERACTIVE -eq "1")
+if ($nonInteractive) {
+    Write-Host "running in non-interactive mode (CODEPLAIN_INSTALL_NONINTERACTIVE=1)"
+}
+
 # Base URL for additional scripts
 if (-not $env:CODEPLAIN_SCRIPTS_BASE_URL) {
     $env:CODEPLAIN_SCRIPTS_BASE_URL = "https://codeplain.ai"
@@ -34,7 +41,7 @@ $env:GRAY_LIGHT = $GRAY_LIGHT
 $env:BOLD = $BOLD
 $env:NC = $NC
 
-Clear-Host
+if (-not $nonInteractive) { Clear-Host }
 Write-Host "started ${YELLOW}${BOLD}*codeplain CLI${NC} installation..."
 
 # Install uv if not present
@@ -94,7 +101,7 @@ if ($codeplainLine) {
     Write-Host "installing codeplain...${NC}"
     Write-Host ""
     uv tool install codeplain
-    Clear-Host
+    if (-not $nonInteractive) { Clear-Host }
     Write-Host "${GREEN}✓ codeplain installed successfully!${NC}"
 }
 
@@ -119,25 +126,34 @@ Write-Host ""
 # Check if API key already exists
 $skipApiKeySetup = $false
 if ($env:CODEPLAIN_API_KEY) {
-    Write-Host "  you already have an API key configured."
-    Write-Host ""
-    Write-Host "  would you like to log in and get a new one?"
-    Write-Host ""
-    $getNewKey = Read-Host "  [y/N]"
-    Write-Host ""
-
-    if ($getNewKey -notmatch '^[Yy]$') {
-        Write-Host "${GREEN}✓${NC} using existing API key."
+    if ($nonInteractive) {
+        Write-Host "${GREEN}✓${NC} using existing CODEPLAIN_API_KEY (non-interactive mode)."
         $skipApiKeySetup = $true
+    } else {
+        Write-Host "  you already have an API key configured."
+        Write-Host ""
+        Write-Host "  would you like to log in and get a new one?"
+        Write-Host ""
+        $getNewKey = Read-Host "  [y/N]"
+        Write-Host ""
+
+        if ($getNewKey -notmatch '^[Yy]$') {
+            Write-Host "${GREEN}✓${NC} using existing API key."
+            $skipApiKeySetup = $true
+        }
     }
 }
 
 $apiKey = $null
 if (-not $skipApiKeySetup) {
-    Write-Host "go to ${YELLOW}https://platform.codeplain.ai${NC} and sign up to get your API key."
-    Write-Host ""
-    $apiKey = Read-Host "paste your API key here"
-    Write-Host ""
+    if ($nonInteractive) {
+        Write-Host "${GRAY}no CODEPLAIN_API_KEY set; skipping key setup (non-interactive mode).${NC}"
+    } else {
+        Write-Host "go to ${YELLOW}https://platform.codeplain.ai${NC} and sign up to get your API key."
+        Write-Host ""
+        $apiKey = Read-Host "paste your API key here"
+        Write-Host ""
+    }
 }
 
 if ($skipApiKeySetup) {
@@ -155,7 +171,7 @@ if ($skipApiKeySetup) {
 }
 
 # ASCII Art Welcome
-Clear-Host
+if (-not $nonInteractive) { Clear-Host }
 Write-Host ""
 Write-Host "${NC}"
 Write-Host "${GRAY}────────────────────────────────────────────${NC}"
@@ -178,10 +194,14 @@ Write-Host ""
 Write-Host ""
 Write-Host "${GRAY}────────────────────────────────────────────${NC}"
 Write-Host ""
-Write-Host "  would you like to get a quick intro to ***plain specification language?"
-Write-Host ""
-$walkthroughChoice = Read-Host "  [Y/n]"
-Write-Host ""
+if ($nonInteractive) {
+    $walkthroughChoice = "n"
+} else {
+    Write-Host "  would you like to get a quick intro to ***plain specification language?"
+    Write-Host ""
+    $walkthroughChoice = Read-Host "  [Y/n]"
+    Write-Host ""
+}
 
 # Determine script directory for local execution
 $ScriptDir = ""
@@ -225,19 +245,23 @@ if ($walkthroughChoice -notmatch '^[Nn]$') {
 }
 
 # Download examples step
-Clear-Host
-Write-Host ""
-Write-Host "${GRAY}────────────────────────────────────────────${NC}"
-Write-Host "  ${YELLOW}${BOLD}Example Projects${NC}"
-Write-Host "${GRAY}────────────────────────────────────────────${NC}"
-Write-Host ""
-Write-Host "  we've prepared some example Plain projects for you"
-Write-Host "  to explore and experiment with."
-Write-Host ""
-Write-Host "  would you like to download them?"
-Write-Host ""
-$downloadExamples = Read-Host "  [Y/n]"
-Write-Host ""
+if ($nonInteractive) {
+    $downloadExamples = "n"
+} else {
+    Clear-Host
+    Write-Host ""
+    Write-Host "${GRAY}────────────────────────────────────────────${NC}"
+    Write-Host "  ${YELLOW}${BOLD}Example Projects${NC}"
+    Write-Host "${GRAY}────────────────────────────────────────────${NC}"
+    Write-Host ""
+    Write-Host "  we've prepared some example Plain projects for you"
+    Write-Host "  to explore and experiment with."
+    Write-Host ""
+    Write-Host "  would you like to download them?"
+    Write-Host ""
+    $downloadExamples = Read-Host "  [Y/n]"
+    Write-Host ""
+}
 
 # Run examples download if user agrees
 if ($downloadExamples -notmatch '^[Nn]$') {
@@ -245,7 +269,7 @@ if ($downloadExamples -notmatch '^[Nn]$') {
 }
 
 # Final message
-Clear-Host
+if (-not $nonInteractive) { Clear-Host }
 Write-Host ""
 Write-Host "${GRAY}────────────────────────────────────────────${NC}"
 Write-Host "  ${YELLOW}${BOLD}You're all set!${NC}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,4 +109,4 @@ exclude = [
 [tool.pytest.ini_options]
 pythonpath = ["src"]
 testpaths = ["tests"]
-norecursedirs = ["tests/data"]
+norecursedirs = ["tests/data", "tests/e2e"]

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,5 +3,6 @@ testpaths = tests
 python_files = test_*.py
 python_classes = Test*
 python_functions = test_*
-# Ignore test data directory (contains fixture files, not actual tests)
-norecursedirs = tests/data
+# Ignore test data directory (contains fixture files, not actual tests).
+# exclude e2e tests from discovered tests because it requires Docker
+norecursedirs = tests/data tests/e2e

--- a/tests/e2e/Dockerfile
+++ b/tests/e2e/Dockerfile
@@ -1,0 +1,31 @@
+# E2E test base image for codeplain CLI.
+#
+# install.sh is intentionally not executed but only COPIED
+# Each pytest test runs install.sh inside a container via `docker exec`, so the installation is re-tested on every run. This must not be cached.
+
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install only the OS tools install.sh needs to bootstrap uv. `uv tool install
+# codeplain` will download its own Python 3.11. We just need *some* python3 on PATH to execute the rendered hello_world.py
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        bash \
+        ca-certificates \
+        curl \
+        git \
+        python3 \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN useradd --create-home --shell /bin/bash e2e
+USER e2e
+WORKDIR /home/e2e
+
+COPY --chown=e2e:e2e install/bash/install.sh /home/e2e/install.sh
+
+ENV PATH="/home/e2e/.local/bin:${PATH}"
+
+RUN mkdir -p /home/e2e/work
+WORKDIR /home/e2e/work
+
+CMD ["tail", "-f", "/dev/null"]

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,0 +1,145 @@
+import os
+import shutil
+import subprocess
+import sys
+import uuid
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CONTAINER_WORKDIR = "/home/e2e/work"
+INSTALL_PS1 = REPO_ROOT / "install" / "powershell" / "install.ps1"
+
+
+def _docker_available() -> bool:
+    return shutil.which("docker") is not None
+
+
+@pytest.fixture(scope="session")
+def docker_image() -> str:
+    if not _docker_available():
+        pytest.skip("docker not available on host")
+    return os.environ.get("CODEPLAIN_E2E_IMAGE", "codeplain-e2e:latest")
+
+
+@pytest.fixture(scope="session")
+def api_key() -> str:
+    key = os.environ.get("CODEPLAIN_API_KEY")
+
+    if key is None:
+        pytest.skip("CODEPLAIN_API_KEY not set")
+    if key == "":
+        pytest.fail("CODEPLAIN_API_KEY is set but empty")
+    return key
+
+
+@pytest.fixture
+def e2e_container(docker_image: str, api_key: str):
+    name = f"codeplain-e2e-{uuid.uuid4().hex[:12]}"
+    run = subprocess.run(
+        [
+            "docker",
+            "run",
+            "-d",
+            "--rm",
+            "--name",
+            name,
+            "-e",
+            f"CODEPLAIN_API_KEY={api_key}",
+            "-e",
+            "CODEPLAIN_INSTALL_NONINTERACTIVE=1",
+            docker_image,
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if run.returncode != 0:
+        pytest.fail(f"docker run failed: {run.stderr}")
+    container_id = run.stdout.strip()
+
+    try:
+        install = subprocess.run(
+            ["docker", "exec", container_id, "bash", "/home/e2e/install.sh"],
+            capture_output=True,
+            text=True,
+            timeout=600,
+            check=False,
+        )
+        assert install.returncode == 0, (
+            f"install.sh failed inside container (rc={install.returncode})\n"
+            f"stdout:\n{install.stdout}\nstderr:\n{install.stderr}"
+        )
+
+        yield container_id
+    finally:
+        subprocess.run(
+            ["docker", "stop", container_id],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+
+@pytest.fixture
+def exec_in_container():
+    def _exec(container_id: str, cmd: str, workdir: str = CONTAINER_WORKDIR, timeout: int = 600):
+        result = subprocess.run(
+            ["docker", "exec", "-w", workdir, container_id, "bash", "-lc", cmd],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+        return result.returncode, result.stdout, result.stderr
+
+    return _exec
+
+
+@pytest.fixture
+def copy_to_container():
+    def _copy(container_id: str, src: Path, dest: str = CONTAINER_WORKDIR + "/"):
+        subprocess.run(
+            ["docker", "cp", str(src), f"{container_id}:{dest}"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+
+    return _copy
+
+
+# No docker on this runner. The install.ps1 and Codeplain CLI runs directly on the windows VM.
+@pytest.fixture(scope="session")
+def codeplain_exe(api_key: str) -> Path:
+    if sys.platform != "win32":
+        pytest.skip("Windows-only fixture")
+
+    env = {
+        **os.environ,
+        "CODEPLAIN_API_KEY": api_key,
+        "CODEPLAIN_INSTALL_NONINTERACTIVE": "1",
+    }
+    result = subprocess.run(
+        ["pwsh", "-NoProfile", "-File", str(INSTALL_PS1)],
+        capture_output=True,
+        text=True,
+        timeout=600,
+        env=env,
+        check=False,
+    )
+    if result.returncode != 0:
+        pytest.fail(
+            f"install.ps1 failed (rc={result.returncode})\n" f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+
+    # uv tool installs binaries to %USERPROFILE%\.local\bin (see install.ps1
+    # line ~102). Resolve the absolute path so our subprocess doesn't depend
+    # on the current process's stale PATH — install.ps1 writes the user PATH
+    # to the registry, but the python process running pytest already cached
+    # its env at startup.
+    exe = Path(os.environ["USERPROFILE"]) / ".local" / "bin" / "codeplain.exe"
+    if not exe.exists():
+        pytest.fail(f"codeplain.exe not found at expected location: {exe}")
+    return exe

--- a/tests/e2e/test_hello_world_python.py
+++ b/tests/e2e/test_hello_world_python.py
@@ -1,0 +1,37 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+# The Linux flow drives codeplain via `docker exec`; Windows runners don't have
+# a Linux Docker daemon, so this whole file is skipped there. The Windows port
+# lives in test_hello_world_python_windows.py.
+pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="Linux/Docker-based e2e")
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+EXAMPLE_PLAIN = REPO_ROOT / "examples" / "example_hello_world_python" / "hello_world_python.plain"
+
+# if it takes longer, it's stuck
+RENDER_TIMEOUT_SECONDS = 180
+
+
+def test_render_and_run_hello_world_python(e2e_container, exec_in_container, copy_to_container):
+    copy_to_container(e2e_container, EXAMPLE_PLAIN)
+
+    rc, out, err = exec_in_container(e2e_container, "codeplain --help")
+    assert rc == 0, f"codeplain not on PATH after install:\nstdout:\n{out}\nstderr:\n{err}"
+
+    rc, out, err = exec_in_container(
+        e2e_container,
+        "codeplain --headless --build-folder build/ hello_world_python.plain",
+        timeout=RENDER_TIMEOUT_SECONDS,
+    )
+    assert rc == 0, f"codeplain render failed (rc={rc}):\nstdout:\n{out}\nstderr:\n{err}"
+
+    generated = "build/hello_world_python/hello_world.py"
+    rc, _, _ = exec_in_container(e2e_container, f"test -f {generated}")
+    assert rc == 0, f"expected generated file at {generated} but it was not produced"
+
+    rc, out, err = exec_in_container(e2e_container, f"python3 {generated}")
+    assert rc == 0, f"generated python failed (rc={rc}):\nstdout:\n{out}\nstderr:\n{err}"
+    assert "hello, world" in out.lower(), f"unexpected stdout from generated app: {out!r}"

--- a/tests/e2e/test_hello_world_python_windows.py
+++ b/tests/e2e/test_hello_world_python_windows.py
@@ -1,0 +1,64 @@
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.skipif(sys.platform != "win32", reason="Windows-only e2e")
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+EXAMPLE_PLAIN = REPO_ROOT / "examples" / "example_hello_world_python" / "hello_world_python.plain"
+
+# if it takes longer, it's stuck
+RENDER_TIMEOUT_SECONDS = 180
+
+
+def test_render_and_run_hello_world_python_windows(codeplain_exe: Path, api_key: str, tmp_path: Path):
+    shutil.copy(EXAMPLE_PLAIN, tmp_path / "hello_world_python.plain")
+
+    env = {**os.environ, "CODEPLAIN_API_KEY": api_key}
+
+    result = subprocess.run(
+        [str(codeplain_exe), "--help"],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        env=env,
+        check=False,
+    )
+    assert result.returncode == 0, f"codeplain --help failed:\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+
+    result = subprocess.run(
+        [
+            str(codeplain_exe),
+            "--headless",
+            "--build-folder",
+            "build/",
+            "hello_world_python.plain",
+        ],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        timeout=RENDER_TIMEOUT_SECONDS,
+        env=env,
+        check=False,
+    )
+    assert result.returncode == 0, (
+        f"codeplain render failed (rc={result.returncode}):\n" f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+
+    generated = tmp_path / "build" / "hello_world_python" / "hello_world.py"
+    assert generated.exists(), f"expected generated file at {generated} but it was not produced"
+
+    result = subprocess.run(
+        ["python", str(generated)],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=env,
+        check=False,
+    )
+    assert result.returncode == 0, f"generated python failed (rc={result.returncode}):\nstderr:\n{result.stderr}"
+    assert "hello, world" in result.stdout.lower(), f"unexpected stdout from generated app: {result.stdout!r}"


### PR DESCRIPTION
This adds a GitHub Actions workflow that uses a linux and a windows environment to:

- test a clean install of Codeplain (it gets the install script from the repo)
- run it on the hello world python example (uses production backend - debatable ❓)
- check if it the generated code works (runs the hello world script)

It is meant to be ran periodically (debatable❓).