### PR TITLE
fix windows UnicodeEncodeError after render completes

### DIFF
--- a/plain2code.py
+++ b/plain2code.py
@@ -68,7 +68,7 @@ def print_exit_summary(
     msg += f"  [#8E8F91]input file:\t\t\t[#FFFFFF]{spec_filename}\n"
     msg += f"  [#8E8F91]generated code folder:\t[#FFFFFF]{run_state.render_generated_code_path or '-'}\n\n"
     msg += f"[#8E8F91]functionalities  [#FFFFFF]{run_state.rendered_functionalities}  [#8E8F91]used credits  [#FFFFFF]{run_state.rendered_functionalities}  [#8E8F91]render time  [#FFFFFF]{format_duration_hms(run_state.render_time_accumulated)}\n"
-    console.info(msg)
+    console.print(msg)
 
     if not run_state.render_succeeded and error_message:
         console.error(error_message)
@@ -118,7 +118,7 @@ def setup_logging(
 
     if log_to_file and log_file_path:
         try:
-            file_handler = logging.FileHandler(log_file_path, mode="w")
+            file_handler = logging.FileHandler(log_file_path, mode="w", encoding="utf-8")
             file_handler.setFormatter(formatter)
             file_handler.setLevel(configured_log_level)
             root_logger.addHandler(file_handler)
@@ -268,6 +268,10 @@ def render(args, run_state: RunState, event_bus: EventBus):  # noqa: C901
 
 
 def main():  # noqa: C901
+    if sys.platform == "win32":
+        sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+        sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+
     args = parse_arguments()
 
     # Handle early-exit flags before heavy initialization

--- a/plain2code_logger.py
+++ b/plain2code_logger.py
@@ -65,7 +65,7 @@ class CrashLogHandler(logging.Handler):
             return False
 
         try:
-            with open(filepath, "w") as f:
+            with open(filepath, "w", encoding="utf-8") as f:
                 for record in self.records:
                     if formatter:
                         msg = formatter.format(record)


### PR DESCRIPTION
The "✓ rendering completed" console output throws an error on Windows because of different encoding.

The error: `UnicodeEncodeError: 'charmap' codec can't encode character '\u2713' in position 42: character maps to <undefined>`