### PR TITLE
Add --status and --version flags to display account, credit information and client version

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,9 @@ Hook is located at `.git/hooks/pre-push`.
 # Basic usage - render a .plain file
 python plain2code.py path/to/file.plain
 
+# Display account status (user info, credits, API key label)
+python plain2code.py --status
+
 # Dry run (parse and validate .plain files without rendering code)
 # This parses the spec files, resolves imports/requires, but doesn't generate code
 python plain2code.py path/to/file.plain --dry-run
@@ -125,8 +128,9 @@ black . --check && isort . --check-only && flake8 . && mypy . --check-untyped-de
 3. **Rendering Orchestration** (`module_renderer.py`): Coordinates render process across modules
 4. **State Machine** (`render_machine/`): Hierarchical state machine drives the render lifecycle
 5. **API Communication** (`codeplain_REST_api.py`): HTTP client for Codeplain API
-6. **Code Generation** (`render_machine/code_renderer.py`): Main code renderer class that orchestrates the code generation workflow using a hierarchical state machine.
+6. **Code Generation** (`render_machine/code_renderer.py`): Main code renderer class that orchestrates the code generation workflow using a hierarchical state machine
 7. **TUI** (`tui/`): Textual-based terminal UI showing render progress
+8. **CLI Output** (`cli_output/`): Non-interactive terminal output formatting for status, dry-run, and render summaries
 
 ### Key Concepts
 
@@ -148,6 +152,8 @@ black . --check && isort . --check-only && flake8 . && mypy . --check-untyped-de
 ### Directory Structure
 
 - `plain2code.py` - Main CLI entry point
+- `plain2code_arguments.py` - CLI argument parsing and validation
+- `plain2code_utils.py` - Pure utility functions (duration formatting, ambiguity messages)
 - `plain_modules.py` - Module dependency resolution
 - `plain_file.py` - `.plain` file parser
 - `plain_spec.py` - Spec extraction and FRID utilities
@@ -158,15 +164,20 @@ black . --check && isort . --check-only && flake8 . && mypy . --check-untyped-de
   - `triggers.py` - State transition logic
   - `render_context.py` - Shared context across states
   - `conformance_tests.py` - Test generation and execution
-- `tui/` - Terminal UI (Textual framework)
+- `tui/` - Interactive terminal UI (Textual framework)
   - `plain2code_tui.py` - Main TUI app
   - `components.py` - Custom UI widgets
+- `cli_output/` - Non-interactive CLI output formatting
+  - `status.py` - Status display (`--status` flag)
+  - `dry_run.py` - Dry run output (`--dry-run` flag)
+  - `render_summary.py` - Render completion summary
 - `codeplain_REST_api.py` - API client
 - `memory_management.py` - Context tracking
 - `git_utils.py` - Git operations for checkpointing
 - `file_utils.py` - File I/O utilities
 - `concept_utils.py` - Concept validation (***plain language feature)
 - `plain2code_logger.py` - Custom logging with elapsed time timestamps
+- `plain2code_console.py` - Rich console wrapper with custom styles
 - `plain2code_state.py` - Runtime state (render ID, counters, timing)
 - `standard_template_library/` - Built-in code templates
 - `examples/` - Sample `.plain` projects

--- a/cli_output/__init__.py
+++ b/cli_output/__init__.py
@@ -1,0 +1,7 @@
+"""CLI output formatting for non-interactive display."""
+
+from cli_output.dry_run import print_dry_run_output
+from cli_output.render_summary import print_exit_summary
+from cli_output.status import print_status
+
+__all__ = ["print_dry_run_output", "print_exit_summary", "print_status"]

--- a/cli_output/dry_run.py
+++ b/cli_output/dry_run.py
@@ -1,0 +1,35 @@
+"""Dry run output display for --dry-run flag."""
+
+from typing import Optional
+
+import plain_spec
+from plain2code_console import console
+
+
+def print_dry_run_output(plain_source_tree: dict, render_range: Optional[list[str]]):
+    """Print dry run output showing what would be rendered."""
+    frid = plain_spec.get_first_frid(plain_source_tree)
+
+    while frid is not None:
+        is_inside_range = render_range is None or frid in render_range
+
+        if is_inside_range:
+            specifications, _ = plain_spec.get_specifications_for_frid(plain_source_tree, frid)
+            functional_requirement_text = specifications[plain_spec.FUNCTIONAL_REQUIREMENTS][-1]
+            console.info(
+                "-------------------------------------\n"
+                f"Rendering functionality {frid}:\n"
+                f"{functional_requirement_text}\n"
+                "-------------------------------------\n"
+            )
+            if plain_spec.ACCEPTANCE_TESTS in specifications:
+                for i, acceptance_test in enumerate(specifications[plain_spec.ACCEPTANCE_TESTS], 1):
+                    console.info(f"Generating acceptance test #{i}:\n\n{acceptance_test}\n")
+        else:
+            console.info(
+                "-------------------------------------\n"
+                f"Skipping rendering iteration: {frid}\n"
+                "-------------------------------------"
+            )
+
+        frid = plain_spec.get_next_frid(plain_source_tree, frid)

--- a/cli_output/render_summary.py
+++ b/cli_output/render_summary.py
@@ -1,0 +1,27 @@
+"""Render completion summary display."""
+
+from typing import Optional
+
+from plain2code_console import console
+from plain2code_state import RunState
+from plain2code_utils import format_duration_hms
+
+
+def print_exit_summary(
+    run_state: RunState,
+    spec_filename: str,
+    error_message: Optional[str] = None,
+) -> None:
+    """Print render outcome after the TUI exits (terminal restored)."""
+    console.quiet = False
+
+    msg = "\n[#79FC96]✓ rendering completed\n\n" if run_state.render_succeeded else "[#FF6B6B]✗ rendering failed\n\n"
+    msg += f"  [#8E8F91]render id:\t\t\t[#FFFFFF]{run_state.render_id}\n"
+    msg += f"  [#8E8F91]input file:\t\t\t[#FFFFFF]{spec_filename}\n"
+    msg += f"  [#8E8F91]generated code folder:\t[#FFFFFF]{run_state.render_generated_code_path or '-'}\n\n"
+    msg += f"[#8E8F91]functionalities  [#FFFFFF]{run_state.rendered_functionalities}  [#8E8F91]used credits  [#FFFFFF]{run_state.rendered_functionalities}  [#8E8F91]render time  [#FFFFFF]{format_duration_hms(run_state.render_time_accumulated)}\n"
+    console.print(msg)
+
+    if not run_state.render_succeeded and error_message:
+        console.error(error_message)
+    console.quiet = True

--- a/cli_output/status.py
+++ b/cli_output/status.py
@@ -1,0 +1,156 @@
+"""Status display for --status flag."""
+
+from datetime import datetime, timezone
+from typing import Optional
+
+import codeplain_REST_api as codeplain_api
+from plain2code_console import console
+
+
+def _create_progress_bar(remaining: int, total: int, width: int = 30) -> str:
+    """Create a Unicode progress bar."""
+    if total == 0:
+        filled = 0
+    else:
+        filled = int((remaining / total) * width)
+
+    empty = width - filled
+    return "█" * filled + "░" * empty
+
+
+def _display_credit_line(plan_credits: dict) -> None:
+    """Display a plan credit line with progress bar."""
+    plan_type = plan_credits["type"]
+    remaining = plan_credits["remaining"]
+    total = plan_credits["total"]
+    period_end = plan_credits["period_end"]
+
+    # Parse ISO-8601 timestamp and format as "Jun 1, 2026"
+    # Handle both with and without timezone info
+    dt_str = period_end.replace("Z", "+00:00")
+    dt = datetime.fromisoformat(dt_str)
+    # If naive datetime, assume UTC
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    formatted_date = dt.strftime("%b %-d, %Y")
+
+    # Check if expired
+    now = datetime.now(timezone.utc)
+    is_expired = dt < now
+
+    # Create progress bar (30 chars wide)
+    bar = _create_progress_bar(remaining, total, width=30)
+
+    # Format plan type label
+    plan_label = "Free trial" if plan_type == "free" else plan_type.upper() + " plan"
+
+    if is_expired:
+        console.print(f"    {plan_label:10} {bar}   expired {formatted_date}")
+    else:
+        console.print(f"    {plan_label:10} {bar}   {remaining:2} of {total} remaining    expires {formatted_date}")
+
+
+def _display_purchased_credit_line(bucket: dict) -> None:
+    """Display a purchased credit line with progress bar."""
+    remaining = bucket["remaining"]
+    total = bucket["total"]
+    expiry_date = bucket["expiry_date"]
+
+    # Parse ISO-8601 timestamp and handle both with and without timezone info
+    dt_str = expiry_date.replace("Z", "+00:00")
+    dt = datetime.fromisoformat(dt_str)
+    # If naive datetime, assume UTC
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    formatted_date = dt.strftime("%b %-d, %Y")
+
+    # Check if expired
+    now = datetime.now(timezone.utc)
+    is_expired = dt < now
+
+    bar = _create_progress_bar(remaining, total, width=30)
+
+    if is_expired:
+        console.print(f"    Purchased  {bar}   expired {formatted_date}")
+    else:
+        console.print(f"    Purchased  {bar}   {remaining:2} of {total} remaining    expires {formatted_date}")
+
+
+def _display_status_message(plan_credits: Optional[dict], purchased_credits: list) -> None:
+    """Display appropriate status message based on credit state."""
+    has_remaining = False
+
+    # Check if plan credits have remaining balance and are not expired
+    if plan_credits:
+        remaining = plan_credits["remaining"]
+        dt_str = plan_credits["period_end"].replace("Z", "+00:00")
+        period_end = datetime.fromisoformat(dt_str)
+        # If naive datetime, assume UTC
+        if period_end.tzinfo is None:
+            period_end = period_end.replace(tzinfo=timezone.utc)
+        now = datetime.now(timezone.utc)
+
+        if remaining > 0 and period_end > now:
+            has_remaining = True
+
+    # Check if any purchased credits have remaining balance and not expired
+    for bucket in purchased_credits:
+        dt_str = bucket["expiry_date"].replace("Z", "+00:00")
+        expiry_date = datetime.fromisoformat(dt_str)
+        # If naive datetime, assume UTC
+        if expiry_date.tzinfo is None:
+            expiry_date = expiry_date.replace(tzinfo=timezone.utc)
+        now = datetime.now(timezone.utc)
+
+        if bucket["remaining"] > 0 and expiry_date > now:
+            has_remaining = True
+            break
+
+    if not has_remaining:
+        console.print("\nNo rendering credits remaining. Upgrade to continue rendering.")
+
+
+def print_status(api_key: str, api_url: str, client_version: str) -> None:
+    """Display account status including user info and rendering credits."""
+    codeplainAPI = codeplain_api.CodeplainAPI(api_key, console)
+    codeplainAPI.api_url = api_url
+
+    # First check client version
+    version_check = codeplainAPI.connection_check(client_version)
+    client_version_valid = version_check.get("client_version_valid", False)
+    min_version = version_check.get("min_client_version", "unknown")
+
+    response = codeplainAPI.status()
+
+    user = response["user"]
+    api_key_label = response["api_key_label"]
+    org_owner = response.get("organization_owner_email")
+    plan_credits = response.get("plan_credits")
+    purchased_credits = response.get("purchased_credits", [])
+
+    # Display header information
+    if client_version_valid:
+        console.print(f"Version: {client_version}")
+    else:
+        from plain2code_console import Plain2CodeConsole
+        console.print(f"Version: {client_version} (outdated — minimum required: {min_version})", style=Plain2CodeConsole.ERROR_STYLE)
+        console.print("To update, run: uv tool upgrade codeplain\n", style=Plain2CodeConsole.ERROR_STYLE)
+    console.print(f"Name: {user['first_name']} {user['last_name']}")
+    console.print(f"User email: {user['email']}")
+    console.print(f"Organization owner: {org_owner or 'N/A'}")
+    console.print(f"API key label: {api_key_label}\n")
+
+    # Display rendering credits section
+    console.print("Rendering credits:")
+
+    # Display plan credits (free trial or subscription)
+    if plan_credits:
+        _display_credit_line(plan_credits)
+
+    # Display purchased credits
+    for bucket in purchased_credits:
+        _display_purchased_credit_line(bucket)
+
+    # Display status messages and management link
+    _display_status_message(plan_credits, purchased_credits)
+    console.print("\nTo manage your plan navigate to https://platform.codeplain.ai/plans")

--- a/cli_output/status.py
+++ b/cli_output/status.py
@@ -133,7 +133,11 @@ def print_status(api_key: str, api_url: str, client_version: str) -> None:
         console.print(f"Version: {client_version}")
     else:
         from plain2code_console import Plain2CodeConsole
-        console.print(f"Version: {client_version} (outdated — minimum required: {min_version})", style=Plain2CodeConsole.ERROR_STYLE)
+
+        console.print(
+            f"Version: {client_version} (outdated — minimum required: {min_version})",
+            style=Plain2CodeConsole.ERROR_STYLE,
+        )
         console.print("To update, run: uv tool upgrade codeplain\n", style=Plain2CodeConsole.ERROR_STYLE)
     console.print(f"Name: {user['first_name']} {user['last_name']}")
     console.print(f"User email: {user['email']}")

--- a/codeplain_REST_api.py
+++ b/codeplain_REST_api.py
@@ -161,6 +161,14 @@ class CodeplainAPI:
         }
         return self.post_request(endpoint_url, headers, payload, None, num_retries=0, silent=True)
 
+    def status(self):
+        endpoint_url = f"{self.api_url}/status"
+        headers = {"Content-Type": "application/json"}
+        payload = {
+            "api_key": self.api_key,
+        }
+        return self.post_request(endpoint_url, headers, payload, None, num_retries=0, silent=True)
+
     def render_functional_requirement(
         self,
         frid: str,

--- a/plain2code.py
+++ b/plain2code.py
@@ -47,7 +47,6 @@ from plain2code_logger import (
     get_log_file_path,
 )
 from plain2code_state import RunState
-from plain2code_utils import format_duration_hms
 from system_config import system_config
 from tui.plain2code_tui import Plain2CodeTUI
 from tui.plain_module_render_choice_tui import PlainModuleRenderChoiceTUI
@@ -253,6 +252,11 @@ def main():  # noqa: C901
         sys.stderr.reconfigure(encoding="utf-8", errors="replace")
 
     args = parse_arguments()
+
+    # Handle --version flag before any other initialization
+    if args.version:
+        console.print(f"codeplain version {system_config.client_version}")
+        return
 
     # Handle --status flag before any other initialization
     if args.status:

--- a/plain2code.py
+++ b/plain2code.py
@@ -16,6 +16,7 @@ import file_utils
 import plain_file
 import plain_modules
 import plain_spec
+from cli_output import print_dry_run_output, print_exit_summary, print_status
 from event_bus import EventBus
 from module_renderer import ModuleRenderer
 from partial_rendering import get_plain_module_render_state, get_render_choices
@@ -46,33 +47,13 @@ from plain2code_logger import (
     get_log_file_path,
 )
 from plain2code_state import RunState
-from plain2code_utils import format_duration_hms, print_dry_run_output
+from plain2code_utils import format_duration_hms
 from system_config import system_config
 from tui.plain2code_tui import Plain2CodeTUI
 from tui.plain_module_render_choice_tui import PlainModuleRenderChoiceTUI
 
 DEFAULT_TEMPLATE_DIRS = importlib.resources.files("standard_template_library")
 RENDER_THREAD_SHUTDOWN_TIMEOUT = 0.7
-
-
-def print_exit_summary(
-    run_state: RunState,
-    spec_filename: str,
-    error_message: Optional[str] = None,
-) -> None:
-    console.quiet = False
-    """Print render outcome after the TUI exits (terminal restored)."""
-
-    msg = "\n[#79FC96]✓ rendering completed\n\n" if run_state.render_succeeded else "[#FF6B6B]✗ rendering failed\n\n"
-    msg += f"  [#8E8F91]render id:\t\t\t[#FFFFFF]{run_state.render_id}\n"
-    msg += f"  [#8E8F91]input file:\t\t\t[#FFFFFF]{spec_filename}\n"
-    msg += f"  [#8E8F91]generated code folder:\t[#FFFFFF]{run_state.render_generated_code_path or '-'}\n\n"
-    msg += f"[#8E8F91]functionalities  [#FFFFFF]{run_state.rendered_functionalities}  [#8E8F91]used credits  [#FFFFFF]{run_state.rendered_functionalities}  [#8E8F91]render time  [#FFFFFF]{format_duration_hms(run_state.render_time_accumulated)}\n"
-    console.print(msg)
-
-    if not run_state.render_succeeded and error_message:
-        console.error(error_message)
-    console.quiet = True
 
 
 def setup_logging(
@@ -148,8 +129,7 @@ def _check_connection(codeplainAPI: codeplain_api.CodeplainAPI):
         raise OutdatedClientVersion(
             "Outdated client version: "
             f"Your client version ({system_config.client_version}) is outdated. Minimum required version is {min_version}. "
-            "Please update using:"
-            "  uv tool upgrade codeplain"
+            "Please update using: uv tool upgrade codeplain"
         )
 
 
@@ -273,6 +253,23 @@ def main():  # noqa: C901
         sys.stderr.reconfigure(encoding="utf-8", errors="replace")
 
     args = parse_arguments()
+
+    # Handle --status flag before any other initialization
+    if args.status:
+        if not args.api_key:
+            console.error(
+                "Your API key is required. Please set the CODEPLAIN_API_KEY environment variable or provide it with the --api-key argument.\n"
+            )
+            return
+
+        if not args.api:
+            args.api = "https://api.codeplain.ai"
+
+        try:
+            print_status(args.api_key, args.api, system_config.client_version)
+        except Exception as e:
+            console.error(f"Error fetching status: {str(e)}")
+        return
 
     # Handle early-exit flags before heavy initialization
     if args.dry_run or args.full_plain:

--- a/plain2code_arguments.py
+++ b/plain2code_arguments.py
@@ -172,6 +172,7 @@ def create_parser():
     parser.add_argument(
         "filename",
         type=str,
+        nargs="?",
         help="Path to the plain file to render. The directory containing this file has highest precedence for template loading, "
         "so you can place custom templates here to override the defaults. See --template-dir for more details about template loading.",
     )
@@ -348,6 +349,14 @@ def create_parser():
         "All logs are written to the log file.",
     )
 
+    parser.add_argument(
+        "--status",
+        action="store_true",
+        default=False,
+        help="Display account status including user information, API key label, and rendering credits. "
+        "Does not render any code.",
+    )
+
     return parser
 
 
@@ -355,7 +364,14 @@ def parse_arguments():
     parser = create_parser()
 
     args = parser.parse_args()
-    args = update_args_with_config(args, parser)
+
+    # Validate filename is provided when needed
+    if not args.status and not args.filename:
+        parser.error("the following arguments are required: filename")
+
+    # Only process config if filename is provided (not needed for --status)
+    if args.filename:
+        args = update_args_with_config(args, parser)
 
     if args.build_folder == args.build_dest:
         parser.error("--build-folder and --build-dest cannot be the same")
@@ -372,6 +388,9 @@ def parse_arguments():
 
     if args.full_plain and args.dry_run:
         parser.error("--full-plain and --dry-run are mutually exclusive")
+
+    if args.status and (args.dry_run or args.full_plain):
+        parser.error("--status cannot be used with --dry-run or --full-plain")
 
     script_arg_names = [UNIT_TESTS_SCRIPT_NAME, CONFORMANCE_TESTS_SCRIPT_NAME, PREPARE_ENVIRONMENT_SCRIPT_NAME]
     for script_name in script_arg_names:

--- a/plain2code_arguments.py
+++ b/plain2code_arguments.py
@@ -357,6 +357,13 @@ def create_parser():
         "Does not render any code.",
     )
 
+    parser.add_argument(
+        "--version",
+        action="store_true",
+        default=False,
+        help="Display the client version and exit.",
+    )
+
     return parser
 
 
@@ -366,7 +373,7 @@ def parse_arguments():
     args = parser.parse_args()
 
     # Validate filename is provided when needed
-    if not args.status and not args.filename:
+    if not args.status and not args.version and not args.filename:
         parser.error("the following arguments are required: filename")
 
     # Only process config if filename is provided (not needed for --status)

--- a/tests/test_cli_output.py
+++ b/tests/test_cli_output.py
@@ -1,6 +1,7 @@
 """Unit tests for cli_output module."""
 
 from datetime import datetime, timezone
+from io import StringIO
 from unittest.mock import Mock, patch
 
 import pytest
@@ -386,3 +387,25 @@ class TestPrintStatus:
         calls = [str(call) for call in mock_console.print.call_args_list]
         purchased_calls = [c for c in calls if "Purchased" in c]
         assert len(purchased_calls) == 2
+
+
+class TestVersionFlag:
+    """Tests for --version flag."""
+
+    def test_version_flag_without_filename(self, capsys):
+        """Test that --version works without providing a filename."""
+        import sys
+
+        import plain2code
+
+        # Save original argv
+        original_argv = sys.argv
+        try:
+            sys.argv = ["plain2code.py", "--version"]
+            # This should not raise an error about missing filename
+            plain2code.main()
+
+            captured = capsys.readouterr()
+            assert "codeplain version" in captured.out
+        finally:
+            sys.argv = original_argv

--- a/tests/test_cli_output.py
+++ b/tests/test_cli_output.py
@@ -1,0 +1,388 @@
+"""Unit tests for cli_output module."""
+
+from datetime import datetime, timezone
+from unittest.mock import Mock, patch
+
+import pytest
+
+from cli_output.status import (
+    _create_progress_bar,
+    _display_credit_line,
+    _display_purchased_credit_line,
+    _display_status_message,
+    print_status,
+)
+
+
+class TestProgressBar:
+    """Tests for _create_progress_bar function."""
+
+    def test_empty_progress_bar(self):
+        """Test progress bar with 0% completion."""
+        bar = _create_progress_bar(0, 100, width=30)
+        assert bar == "░" * 30
+        assert len(bar) == 30
+
+    def test_full_progress_bar(self):
+        """Test progress bar with 100% completion."""
+        bar = _create_progress_bar(100, 100, width=30)
+        assert bar == "█" * 30
+        assert len(bar) == 30
+
+    def test_half_progress_bar(self):
+        """Test progress bar with 50% completion."""
+        bar = _create_progress_bar(50, 100, width=30)
+        assert bar == "█" * 15 + "░" * 15
+        assert len(bar) == 30
+
+    def test_small_progress(self):
+        """Test progress bar with small percentage."""
+        bar = _create_progress_bar(4, 50, width=30)
+        assert bar.startswith("██")
+        assert bar.endswith("░")
+        assert len(bar) == 30
+
+    def test_zero_total(self):
+        """Test progress bar with zero total (edge case)."""
+        bar = _create_progress_bar(0, 0, width=30)
+        assert bar == "░" * 30
+        assert len(bar) == 30
+
+    def test_custom_width(self):
+        """Test progress bar with custom width."""
+        bar = _create_progress_bar(5, 10, width=10)
+        assert len(bar) == 10
+        assert bar == "█" * 5 + "░" * 5
+
+
+class TestDisplayCreditLine:
+    """Tests for _display_credit_line function."""
+
+    @patch("cli_output.status.console")
+    def test_display_active_free_trial(self, mock_console):
+        """Test displaying active free trial credits."""
+        plan_credits = {
+            "type": "free",
+            "total": 50,
+            "remaining": 4,
+            "period_end": "2026-06-01T00:00:00+00:00",
+        }
+        _display_credit_line(plan_credits)
+
+        mock_console.print.assert_called_once()
+        call_args = mock_console.print.call_args[0][0]
+        assert "Free trial" in call_args
+        assert "4 of 50 remaining" in call_args
+        assert "expires Jun 1, 2026" in call_args
+
+    @patch("cli_output.status.console")
+    def test_display_active_pro_plan(self, mock_console):
+        """Test displaying active PRO plan credits."""
+        plan_credits = {
+            "type": "pro",
+            "total": 1000,
+            "remaining": 200,
+            "period_end": "2026-07-15T00:00:00+00:00",
+        }
+        _display_credit_line(plan_credits)
+
+        call_args = mock_console.print.call_args[0][0]
+        assert "PRO plan" in call_args
+        assert "200 of 1000 remaining" in call_args
+        assert "expires Jul 15, 2026" in call_args
+
+    @patch("cli_output.status.console")
+    def test_display_expired_credits(self, mock_console):
+        """Test displaying expired credits."""
+        plan_credits = {
+            "type": "free",
+            "total": 50,
+            "remaining": 4,
+            "period_end": "2024-05-01T00:00:00+00:00",
+        }
+        _display_credit_line(plan_credits)
+
+        call_args = mock_console.print.call_args[0][0]
+        assert "expired May 1, 2024" in call_args
+        assert "remaining" not in call_args
+
+    @patch("cli_output.status.console")
+    def test_display_exhausted_credits(self, mock_console):
+        """Test displaying exhausted but not expired credits."""
+        plan_credits = {
+            "type": "free",
+            "total": 50,
+            "remaining": 0,
+            "period_end": "2026-06-01T00:00:00+00:00",
+        }
+        _display_credit_line(plan_credits)
+
+        call_args = mock_console.print.call_args[0][0]
+        assert "0 of 50 remaining" in call_args
+        assert "expires Jun 1, 2026" in call_args
+
+    @patch("cli_output.status.console")
+    def test_timezone_naive_datetime(self, mock_console):
+        """Test handling of timezone-naive datetime."""
+        plan_credits = {
+            "type": "free",
+            "total": 50,
+            "remaining": 4,
+            "period_end": "2026-12-31T23:59:59",  # No timezone
+        }
+        # Should not raise exception
+        _display_credit_line(plan_credits)
+        mock_console.print.assert_called_once()
+
+
+class TestDisplayPurchasedCreditLine:
+    """Tests for _display_purchased_credit_line function."""
+
+    @patch("cli_output.status.console")
+    def test_display_active_purchased_credits(self, mock_console):
+        """Test displaying active purchased credits."""
+        bucket = {
+            "total": 100,
+            "remaining": 20,
+            "expiry_date": "2026-06-12T00:00:00+00:00",
+        }
+        _display_purchased_credit_line(bucket)
+
+        call_args = mock_console.print.call_args[0][0]
+        assert "Purchased" in call_args
+        assert "20 of 100 remaining" in call_args
+        assert "expires Jun 12, 2026" in call_args
+
+    @patch("cli_output.status.console")
+    def test_display_expired_purchased_credits(self, mock_console):
+        """Test displaying expired purchased credits."""
+        bucket = {
+            "total": 100,
+            "remaining": 20,
+            "expiry_date": "2024-01-01T00:00:00+00:00",
+        }
+        _display_purchased_credit_line(bucket)
+
+        call_args = mock_console.print.call_args[0][0]
+        assert "expired Jan 1, 2024" in call_args
+        assert "remaining" not in call_args
+
+    @patch("cli_output.status.console")
+    def test_timezone_naive_datetime(self, mock_console):
+        """Test handling of timezone-naive datetime."""
+        bucket = {
+            "total": 100,
+            "remaining": 20,
+            "expiry_date": "2026-06-12T00:00:00",  # No timezone
+        }
+        # Should not raise exception
+        _display_purchased_credit_line(bucket)
+        mock_console.print.assert_called_once()
+
+
+class TestDisplayStatusMessage:
+    """Tests for _display_status_message function."""
+
+    @patch("cli_output.status.console")
+    def test_has_active_plan_credits(self, mock_console):
+        """Test when user has active plan credits."""
+        plan_credits = {
+            "remaining": 10,
+            "period_end": "2026-06-01T00:00:00+00:00",
+        }
+        _display_status_message(plan_credits, [])
+
+        # Should not print warning message
+        mock_console.print.assert_not_called()
+
+    @patch("cli_output.status.console")
+    def test_has_active_purchased_credits(self, mock_console):
+        """Test when user has active purchased credits."""
+        purchased_credits = [
+            {
+                "remaining": 20,
+                "expiry_date": "2026-06-12T00:00:00+00:00",
+            }
+        ]
+        _display_status_message(None, purchased_credits)
+
+        # Should not print warning message
+        mock_console.print.assert_not_called()
+
+    @patch("cli_output.status.console")
+    def test_no_credits_remaining(self, mock_console):
+        """Test when user has no credits remaining."""
+        plan_credits = {
+            "remaining": 0,
+            "period_end": "2026-06-01T00:00:00+00:00",
+        }
+        _display_status_message(plan_credits, [])
+
+        mock_console.print.assert_called_once()
+        call_args = mock_console.print.call_args[0][0]
+        assert "No rendering credits remaining" in call_args
+
+    @patch("cli_output.status.console")
+    def test_expired_plan_credits(self, mock_console):
+        """Test when plan credits are expired."""
+        plan_credits = {
+            "remaining": 10,
+            "period_end": "2024-01-01T00:00:00+00:00",
+        }
+        _display_status_message(plan_credits, [])
+
+        mock_console.print.assert_called_once()
+        call_args = mock_console.print.call_args[0][0]
+        assert "No rendering credits remaining" in call_args
+
+    @patch("cli_output.status.console")
+    def test_null_plan_credits_and_empty_purchased(self, mock_console):
+        """Test when plan_credits is None and purchased_credits is empty."""
+        _display_status_message(None, [])
+
+        mock_console.print.assert_called_once()
+        call_args = mock_console.print.call_args[0][0]
+        assert "No rendering credits remaining" in call_args
+
+
+class TestPrintStatus:
+    """Tests for print_status function."""
+
+    @patch("cli_output.status.codeplain_api.CodeplainAPI")
+    @patch("cli_output.status.console")
+    def test_valid_client_version(self, mock_console, mock_api_class):
+        """Test status display with valid client version."""
+        # Setup mock API
+        mock_api = Mock()
+        mock_api_class.return_value = mock_api
+        mock_api.connection_check.return_value = {
+            "client_version_valid": True,
+            "min_client_version": "0.3.0",
+        }
+        mock_api.status.return_value = {
+            "user": {
+                "first_name": "John",
+                "last_name": "Doe",
+                "email": "john@example.com",
+            },
+            "api_key_label": "test-key",
+            "organization_owner_email": "owner@example.com",
+            "plan_credits": {
+                "type": "free",
+                "total": 50,
+                "remaining": 10,
+                "period_end": "2026-06-01T00:00:00+00:00",
+            },
+            "purchased_credits": [],
+        }
+
+        print_status("fake-key", "http://localhost:5000", "0.3.0")
+
+        # Verify console.print was called with version info
+        calls = [str(call) for call in mock_console.print.call_args_list]
+        version_call = next((c for c in calls if "Version: 0.3.0" in c), None)
+        assert version_call is not None
+        assert "outdated" not in str(version_call)
+
+    @patch("cli_output.status.codeplain_api.CodeplainAPI")
+    @patch("cli_output.status.console")
+    def test_outdated_client_version(self, mock_console, mock_api_class):
+        """Test status display with outdated client version."""
+        # Setup mock API
+        mock_api = Mock()
+        mock_api_class.return_value = mock_api
+        mock_api.connection_check.return_value = {
+            "client_version_valid": False,
+            "min_client_version": "0.5.0",
+        }
+        mock_api.status.return_value = {
+            "user": {
+                "first_name": "John",
+                "last_name": "Doe",
+                "email": "john@example.com",
+            },
+            "api_key_label": "test-key",
+            "organization_owner_email": "owner@example.com",
+            "plan_credits": None,
+            "purchased_credits": [],
+        }
+
+        print_status("fake-key", "http://localhost:5000", "0.2.0")
+
+        # Verify error-styled version message
+        calls = [str(call) for call in mock_console.print.call_args_list]
+        version_calls = [c for c in calls if "Version: 0.2.0" in c]
+        assert len(version_calls) > 0
+        outdated_call = next((c for c in version_calls if "outdated" in c), None)
+        assert outdated_call is not None
+        assert "minimum required: 0.5.0" in outdated_call
+
+    @patch("cli_output.status.codeplain_api.CodeplainAPI")
+    @patch("cli_output.status.console")
+    def test_no_organization_owner(self, mock_console, mock_api_class):
+        """Test status display when no organization owner exists."""
+        mock_api = Mock()
+        mock_api_class.return_value = mock_api
+        mock_api.connection_check.return_value = {
+            "client_version_valid": True,
+            "min_client_version": "0.3.0",
+        }
+        mock_api.status.return_value = {
+            "user": {
+                "first_name": "John",
+                "last_name": "Doe",
+                "email": "john@example.com",
+            },
+            "api_key_label": "test-key",
+            "organization_owner_email": None,
+            "plan_credits": None,
+            "purchased_credits": [],
+        }
+
+        print_status("fake-key", "http://localhost:5000", "0.3.0")
+
+        # Verify N/A is displayed for organization owner
+        calls = [str(call) for call in mock_console.print.call_args_list]
+        org_call = next((c for c in calls if "Organization owner" in c), None)
+        assert org_call is not None
+        assert "N/A" in org_call
+
+    @patch("cli_output.status.codeplain_api.CodeplainAPI")
+    @patch("cli_output.status.console")
+    def test_multiple_purchased_credit_buckets(self, mock_console, mock_api_class):
+        """Test status display with multiple purchased credit buckets."""
+        mock_api = Mock()
+        mock_api_class.return_value = mock_api
+        mock_api.connection_check.return_value = {
+            "client_version_valid": True,
+            "min_client_version": "0.3.0",
+        }
+        mock_api.status.return_value = {
+            "user": {
+                "first_name": "John",
+                "last_name": "Doe",
+                "email": "john@example.com",
+            },
+            "api_key_label": "test-key",
+            "organization_owner_email": "owner@example.com",
+            "plan_credits": None,
+            "purchased_credits": [
+                {
+                    "total": 100,
+                    "remaining": 50,
+                    "expiry_date": "2026-06-12T00:00:00+00:00",
+                },
+                {
+                    "total": 200,
+                    "remaining": 100,
+                    "expiry_date": "2026-12-31T00:00:00+00:00",
+                },
+            ],
+        }
+
+        print_status("fake-key", "http://localhost:5000", "0.3.0")
+
+        # Verify both buckets are displayed
+        calls = [str(call) for call in mock_console.print.call_args_list]
+        purchased_calls = [c for c in calls if "Purchased" in c]
+        assert len(purchased_calls) == 2


### PR DESCRIPTION
Implements a new --status flag that displays:
- User information (name, email, organization owner)
- API key label
- Rendering credits (plan credits and purchased credits)
- Progress bars showing credit usage
- Expiration dates
- Warning messages when credits are exhausted
- Outdated client version warnings in red

Changes:
- Add cli_output/ module for non-interactive CLI output formatting
  - status.py: Status display with progress bars
  - dry_run.py: Dry run output (moved from plain2code_utils.py)
  - render_summary.py: Render exit summary (moved from plain2code.py)
- Add --status argument to plain2code_arguments.py
- Add status() method to codeplain_REST_api.py
- Update plain2code.py to handle --status early-exit
- Add comprehensive unit tests in test_cli_output.py (23 tests)
- Update CLAUDE.md documentation

Features:
- Handles both timezone-aware and naive datetimes from API
- Shows red/bold text for outdated client versions
- Displays "expired" vs "expires" based on date
- Handles null/empty credit states gracefully
- Mutually exclusive with --dry-run and --full-plain

Testing:
- 23 unit tests covering all status display functions
- Edge cases: expired credits, timezone handling, null values
- Mock API responses for isolated testing