### PR TITLE
Repurpose --verbose to control default log level

### DIFF
--- a/module_renderer.py
+++ b/module_renderer.py
@@ -60,7 +60,6 @@ class ModuleRenderer:
             render_range=render_range,
             render_conformance_tests=self.args.render_conformance_tests,
             base_folder=self.args.base_folder,
-            verbose=self.args.verbose,
             run_state=self.run_state,
             event_bus=self.event_bus,
             test_script_timeout=self.args.test_script_timeout,

--- a/plain2code.py
+++ b/plain2code.py
@@ -84,29 +84,30 @@ def setup_logging(
     plain_file_path: Optional[str],
     headless: bool = False,
 ):
-    # Set default level to INFO for everything not explicitly configured
-    logging.getLogger().setLevel(logging.INFO)
-    logging.getLogger(LOGGER_NAME).setLevel(logging.INFO)
+    default_level = logging.DEBUG if args.verbose else logging.INFO
+
+    logging.getLogger().setLevel(default_level)
+    logging.getLogger(LOGGER_NAME).setLevel(default_level)
     logging.getLogger("git").setLevel(logging.WARNING)
     logging.getLogger("transitions").setLevel(logging.ERROR)
     logging.getLogger("transitions.extensions.diagrams").setLevel(logging.ERROR)
 
     log_file_path = get_log_file_path(plain_file_path, log_file_name)
 
-    # Try to load logging configuration from YAML file
+    # Try to load logging configuration from YAML file (takes precedence over --verbose)
+    config_loaded = False
     if args.logging_config_path and os.path.exists(args.logging_config_path):
         try:
             with open(args.logging_config_path, "r") as f:
                 config = yaml.safe_load(f)
                 logging.config.dictConfig(config)
                 console.info(f"Loaded logging configuration from {args.logging_config_path}")
+                config_loaded = True
         except Exception as e:
             console.warning(f"Failed to load logging configuration from {args.logging_config_path}: {str(e)}")
 
-    # The IndentedFormatter provides better multiline log readability.
-    # We add the LoggingHandler to the root logger.
     root_logger = logging.getLogger(LOGGER_NAME)
-    configured_log_level = root_logger.level
+    configured_log_level = root_logger.level if config_loaded else default_level
     root_logger.setLevel(logging.DEBUG)  # Capture all logs; handlers will filter levels as needed
 
     formatter = IndentedFormatter("%(levelname)s:%(name)s:%(message)s")
@@ -125,12 +126,12 @@ def setup_logging(
         except Exception as e:
             console.warning(f"Failed to setup file logging to {log_file_path}: {str(e)}")
     else:
-        # If file logging is disabled, use CrashLogHandler to buffer logs in memory
-        # in case we need to dump them on crash.
         crash_handler = CrashLogHandler()
         crash_handler.setFormatter(formatter)
         crash_handler.setLevel(configured_log_level)
         root_logger.addHandler(crash_handler)
+
+    return logging.getLevelName(configured_log_level)
 
 
 def _check_connection(codeplainAPI: codeplain_api.CodeplainAPI):
@@ -153,7 +154,7 @@ def _check_connection(codeplainAPI: codeplain_api.CodeplainAPI):
         )
 
 
-def render(args, run_state: RunState, event_bus: EventBus):  # noqa: C901
+def render(args, run_state: RunState, event_bus: EventBus, default_log_level: str = "INFO"):  # noqa: C901
     template_dirs = file_utils.get_template_directories(args.filename, args.template_dir, DEFAULT_TEMPLATE_DIRS)
 
     # Compute render range from either --render-range or --render-from
@@ -164,7 +165,6 @@ def render(args, run_state: RunState, event_bus: EventBus):  # noqa: C901
         render_range = plain_spec.compute_render_range(args, plain_source)
 
     codeplainAPI = codeplain_api.CodeplainAPI(args.api_key, console)
-    codeplainAPI.verbose = args.verbose
     assert args.api is not None and args.api != "", "API URL is required"
     codeplainAPI.api_url = args.api
 
@@ -256,6 +256,7 @@ def render(args, run_state: RunState, event_bus: EventBus):  # noqa: C901
             prepare_environment_script=args.prepare_environment_script,
             state_machine_version=system_config.client_version,
             enter_pause_event=enter_pause_event,
+            default_log_level=default_log_level,
             css_path="styles.css",
         )
         app.run()
@@ -308,7 +309,9 @@ def main():  # noqa: C901
         # Suppress Rich console output.
         console.quiet = True
 
-    setup_logging(args, event_bus, run_state, args.log_to_file, args.log_file_name, args.filename, args.headless)
+    default_log_level = setup_logging(
+        args, event_bus, run_state, args.log_to_file, args.log_file_name, args.filename, args.headless
+    )
 
     exc_info = None
     error_message = None
@@ -319,7 +322,7 @@ def main():  # noqa: C901
             raise MissingAPIKey(
                 "Your API key is required. Please set the CODEPLAIN_API_KEY environment variable or provide it with the --api-key argument.\n"
             )
-        render(args, run_state, event_bus)
+        render(args, run_state, event_bus, default_log_level)
     except BaseException as e:
         if isinstance(e, KeyboardInterrupt):
             error_message = "Keyboard interrupt"

--- a/plain2code_arguments.py
+++ b/plain2code_arguments.py
@@ -176,7 +176,11 @@ def create_parser():
         "so you can place custom templates here to override the defaults. See --template-dir for more details about template loading.",
     )
     parser.add_argument(
-        "--verbose", "-v", action="store_true", default=True, help="Enable verbose output (default: enabled)"
+        "--verbose",
+        "-v",
+        action="store_true",
+        default=False,
+        help="Set default log level to DEBUG for TUI and file logs",
     )
     parser.add_argument("--base-folder", type=str, help="Base folder for the build files")
     parser.add_argument(

--- a/plain2code_console.py
+++ b/plain2code_console.py
@@ -59,12 +59,14 @@ class Plain2CodeConsole(Console):
 
     def print_list(self, items, style=None):
         for item in items:
+            logger.debug(f"  {item}")
             super().print(f"{item}", style=style)
 
     def print_files(self, header, root_folder, files, style=None):
         if not files:
             return
 
+        logger.debug(f"{header} {', '.join(files.keys())}")
         tree = self._create_tree_from_files(root_folder, files)
         super().print(f"\n{header}", style=style)
 

--- a/render_machine/actions/fix_conformance_test.py
+++ b/render_machine/actions/fix_conformance_test.py
@@ -68,30 +68,29 @@ class FixConformanceTest(BaseAction):
         if conflicting_module_name != current_testing_module_name or conflicting_frid != current_testing_frid:
             render_context.conformance_tests_running_context.conflicting_requirement_count = 0
 
-        if render_context.verbose:
-            tmp_resources_list = []
-            plain_spec.collect_linked_resources(
-                render_context.plain_source_tree,
-                tmp_resources_list,
-                None,
-                False,
-                render_context.frid_context.frid,
-            )
-            console.print_resources(tmp_resources_list, render_context.frid_context.linked_resources)
+        tmp_resources_list = []
+        plain_spec.collect_linked_resources(
+            render_context.plain_source_tree,
+            tmp_resources_list,
+            None,
+            False,
+            render_context.frid_context.frid,
+        )
+        console.print_resources(tmp_resources_list, render_context.frid_context.linked_resources)
 
-            console.print_files(
-                "Implementation files sent as input for fixing conformance tests issues:",
-                render_context.build_folder,
-                existing_files_content,
-                style=console.INPUT_STYLE,
-            )
+        console.print_files(
+            "Implementation files sent as input for fixing conformance tests issues:",
+            render_context.build_folder,
+            existing_files_content,
+            style=console.INPUT_STYLE,
+        )
 
-            console.print_files(
-                "Conformance tests files sent as input for fixing conformance tests issues:",
-                render_context.conformance_tests_running_context.get_current_conformance_test_folder_name(),
-                existing_conformance_test_files_content,
-                style=console.INPUT_STYLE,
-            )
+        console.print_files(
+            "Conformance tests files sent as input for fixing conformance tests issues:",
+            render_context.conformance_tests_running_context.get_current_conformance_test_folder_name(),
+            existing_conformance_test_files_content,
+            style=console.INPUT_STYLE,
+        )
 
         [issue_reason_code, response_files] = render_context.codeplain_api.fix_conformance_tests_issue(
             render_context.frid_context.frid,
@@ -144,13 +143,12 @@ class FixConformanceTest(BaseAction):
                 file_utils.store_response_files(render_context.build_folder, response_files, existing_files)
                 code_diff_files_content = diff_utils.get_code_diff(response_files, existing_files_content)
                 render_context.conformance_tests_running_context.code_diff_files = code_diff_files_content
-                if render_context.verbose:
-                    console.print_files(
-                        "Files fixed:",
-                        render_context.build_folder,
-                        response_files,
-                        style=console.OUTPUT_STYLE,
-                    )
+                console.print_files(
+                    "Files fixed:",
+                    render_context.build_folder,
+                    response_files,
+                    style=console.OUTPUT_STYLE,
+                )
                 render_context.conformance_tests_running_context.should_prepare_testing_environment = True
 
                 # Record which test triggered the change and transition to retry phase

--- a/render_machine/actions/fix_unit_tests.py
+++ b/render_machine/actions/fix_unit_tests.py
@@ -30,10 +30,7 @@ class FixUnitTests(BaseAction):
             render_context.build_folder
         )
 
-        if render_context.verbose:
-            render_utils.print_inputs(
-                render_context, existing_files_content, "Files sent as input to unit tests fixing:"
-            )
+        render_utils.print_inputs(render_context, existing_files_content, "Files sent as input to unit tests fixing:")
 
         response_files = render_context.codeplain_api.fix_unittests_issue(
             render_context.frid_context.frid,
@@ -52,7 +49,6 @@ class FixUnitTests(BaseAction):
 
         render_context.unit_tests_running_context.changed_files.update(changed_files)
 
-        if render_context.verbose:
-            console.print_files("Files fixed:", render_context.build_folder, response_files, style=console.OUTPUT_STYLE)
+        console.print_files("Files fixed:", render_context.build_folder, response_files, style=console.OUTPUT_STYLE)
 
         return self.SUCCESSFUL_OUTCOME, None

--- a/render_machine/actions/prepare_repositories.py
+++ b/render_machine/actions/prepare_repositories.py
@@ -22,8 +22,7 @@ class PrepareRepositories(BaseAction):
 
             previous_frid = plain_spec.get_previous_frid(render_context.plain_source_tree, frid)
 
-            if render_context.verbose:
-                console.debug(f"Reverting code to version implemented for {previous_frid}.")
+            console.debug(f"Reverting code to version implemented for {previous_frid}.")
 
             git_utils.revert_to_commit_with_frid(render_context.build_folder, previous_frid)
             # conformance tests are still not fully implemented
@@ -41,8 +40,7 @@ class PrepareRepositories(BaseAction):
 
             if render_context.required_modules:
                 previous_module = render_context.required_modules[-1]
-                if render_context.verbose:
-                    console.debug(f"Cloning git repo from module {previous_module.module_name}.")
+                console.debug(f"Cloning git repo from module {previous_module.module_name}.")
 
                 file_utils.delete_folder(render_context.build_folder)
                 git_utils.clone_repo(
@@ -53,8 +51,7 @@ class PrepareRepositories(BaseAction):
                     initial_files,
                 )
             else:
-                if render_context.verbose:
-                    console.debug("Initializing git repositories for the render folders.")
+                console.debug("Initializing git repositories for the render folders.")
 
                 git_utils.init_git_repo(
                     render_context.build_folder,

--- a/render_machine/actions/prepare_testing_environment.py
+++ b/render_machine/actions/prepare_testing_environment.py
@@ -12,14 +12,12 @@ class PrepareTestingEnvironment(BaseAction):
     FAILED_OUTCOME = "testing_environment_preparation_failed"
 
     def execute(self, render_context: RenderContext, _previous_action_payload: Any | None):
-        if render_context.verbose:
-            console.info(
-                f"Running testing environment preparation script {render_context.prepare_environment_script} for build folder {render_context.build_folder}."
-            )
+        console.info(
+            f"Running testing environment preparation script {render_context.prepare_environment_script} for build folder {render_context.build_folder}."
+        )
         exit_code, _, preparation_temp_file_path = render_utils.execute_script(
             render_context.prepare_environment_script,
             [render_context.build_folder],
-            render_context.verbose,
             "Testing Environment Preparation",
             timeout=render_context.test_script_timeout,
             stop_event=render_context.stop_event,

--- a/render_machine/actions/refactor_code.py
+++ b/render_machine/actions/refactor_code.py
@@ -16,16 +16,14 @@ class RefactorCode(BaseAction):
             render_context.build_folder
         )
 
-        if render_context.verbose:
-            console.debug(f"Refactoring iteration {render_context.frid_context.refactoring_iteration}.")
+        console.debug(f"Refactoring iteration {render_context.frid_context.refactoring_iteration}.")
 
-        if render_context.verbose:
-            console.print_files(
-                "Files sent as input for refactoring:",
-                render_context.build_folder,
-                existing_files_content,
-                style=console.INPUT_STYLE,
-            )
+        console.print_files(
+            "Files sent as input for refactoring:",
+            render_context.build_folder,
+            existing_files_content,
+            style=console.INPUT_STYLE,
+        )
 
         response_files = render_context.codeplain_api.refactor_source_files_if_needed(
             frid=render_context.frid_context.frid,
@@ -36,14 +34,12 @@ class RefactorCode(BaseAction):
         )
 
         if len(response_files) == 0:
-            if render_context.verbose:
-                console.debug("No files refactored.")
+            console.debug("No files refactored.")
             return self.NO_FILES_REFACTORED_OUTCOME, None
 
         file_utils.store_response_files(render_context.build_folder, response_files, existing_files)
 
-        if render_context.verbose:
-            console.print_files(
-                "Files refactored:", render_context.build_folder, response_files, style=console.OUTPUT_STYLE
-            )
+        console.print_files(
+            "Files refactored:", render_context.build_folder, response_files, style=console.OUTPUT_STYLE
+        )
         return self.SUCCESSFUL_OUTCOME, None

--- a/render_machine/actions/render_conformance_tests.py
+++ b/render_machine/actions/render_conformance_tests.py
@@ -45,14 +45,13 @@ class RenderConformanceTests(BaseAction):
     def _render_conformance_tests(self, render_context: RenderContext):
         # Check if tests already exist (e.g., during regression) - if so, skip rendering
         if not render_context.conformance_tests_running_context.current_conformance_tests_exist():
-            if render_context.verbose:
-                console.info("Implementing test requirements:")
-                console.print_list(
-                    render_context.conformance_tests_running_context.current_testing_frid_specifications[
-                        plain_spec.TEST_REQUIREMENTS
-                    ],
-                    style=console.INFO_STYLE,
-                )
+            console.info("Implementing test requirements:")
+            console.print_list(
+                render_context.conformance_tests_running_context.current_testing_frid_specifications[
+                    plain_spec.TEST_REQUIREMENTS
+                ],
+                style=console.INFO_STYLE,
+            )
             fr_subfolder_name = render_context.codeplain_api.generate_folder_name_from_functional_requirement(
                 frid=render_context.conformance_tests_running_context.current_testing_frid,
                 module_name=render_context.conformance_tests_running_context.current_testing_module_name,
@@ -72,8 +71,7 @@ class RenderConformanceTests(BaseAction):
                 fr_subfolder_name,
             )
 
-            if render_context.verbose:
-                console.debug(f"Storing conformance test files in subfolder {conformance_tests_folder_name}/")
+            console.debug(f"Storing conformance test files in subfolder {conformance_tests_folder_name}/")
 
             render_context.conformance_tests_running_context.get_conformance_tests_json(
                 render_context.conformance_tests_running_context.current_testing_module_name
@@ -90,27 +88,26 @@ class RenderConformanceTests(BaseAction):
 
         _, existing_files_content = ImplementationCodeHelpers.fetch_existing_files(render_context.build_folder)
         _, memory_files_content = MemoryManager.fetch_memory_files(render_context.memory_manager.memory_folder)
-        if render_context.verbose:
-            tmp_resources_list = []
-            plain_spec.collect_linked_resources(
-                render_context.plain_source_tree,
-                tmp_resources_list,
-                [
-                    plain_spec.DEFINITIONS,
-                    plain_spec.TEST_REQUIREMENTS,
-                    plain_spec.FUNCTIONAL_REQUIREMENTS,
-                ],
-                False,
-                render_context.frid_context.frid,
-            )
-            console.print_resources(tmp_resources_list, render_context.frid_context.linked_resources)
+        tmp_resources_list = []
+        plain_spec.collect_linked_resources(
+            render_context.plain_source_tree,
+            tmp_resources_list,
+            [
+                plain_spec.DEFINITIONS,
+                plain_spec.TEST_REQUIREMENTS,
+                plain_spec.FUNCTIONAL_REQUIREMENTS,
+            ],
+            False,
+            render_context.frid_context.frid,
+        )
+        console.print_resources(tmp_resources_list, render_context.frid_context.linked_resources)
 
-            console.print_files(
-                "Files sent as input for generating conformance tests:",
-                render_context.build_folder,
-                existing_files_content,
-                style=console.INPUT_STYLE,
-            )
+        console.print_files(
+            "Files sent as input for generating conformance tests:",
+            render_context.build_folder,
+            existing_files_content,
+            style=console.INPUT_STYLE,
+        )
 
         all_acceptance_tests = render_context.frid_context.specifications.get(plain_spec.ACCEPTANCE_TESTS, [])
 
@@ -137,13 +134,12 @@ class RenderConformanceTests(BaseAction):
 
         file_utils.store_response_files(conformance_tests_folder_name, response_files, [])
 
-        if render_context.verbose:
-            console.print_files(
-                "Conformance test files generated:",
-                conformance_tests_folder_name,
-                response_files,
-                style=console.OUTPUT_STYLE,
-            )
+        console.print_files(
+            "Conformance test files generated:",
+            conformance_tests_folder_name,
+            response_files,
+            style=console.OUTPUT_STYLE,
+        )
 
         return self.SUCCESSFUL_OUTCOME, None
 
@@ -169,8 +165,7 @@ class RenderConformanceTests(BaseAction):
             render_context.conformance_tests_running_context.acceptance_tests_completed - 1
         ]
 
-        if render_context.verbose:
-            console.info(f"Generating acceptance test:\n  {acceptance_test}")
+        console.info(f"Generating acceptance test:\n  {acceptance_test}")
 
         response_files = render_context.codeplain_api.render_acceptance_tests(
             render_context.frid_context.frid,

--- a/render_machine/actions/render_functional_requirement.py
+++ b/render_machine/actions/render_functional_requirement.py
@@ -24,21 +24,17 @@ class RenderFunctionalRequirement(BaseAction):
         )
         _, memory_files_content = MemoryManager.fetch_memory_files(render_context.memory_manager.memory_folder)
 
-        if render_context.verbose:
-            msg = "-------------------------------------\n"
-            msg += f"Module: {render_context.module_name}\n"
-            msg += f"Rendering functionality {render_context.frid_context.frid}"
-            if render_context.frid_context.functional_requirement_render_attempts > 1:
-                msg += f", attempt number {render_context.frid_context.functional_requirement_render_attempts}/{MAX_CODE_GENERATION_RETRIES}"
-            msg += f":\n{render_context.frid_context.functional_requirement_text}\n"
-            msg += "-------------------------------------"
-            console.info(msg)
+        msg = "-------------------------------------\n"
+        msg += f"Module: {render_context.module_name}\n"
+        msg += f"Rendering functionality {render_context.frid_context.frid}"
+        if render_context.frid_context.functional_requirement_render_attempts > 1:
+            msg += f", attempt number {render_context.frid_context.functional_requirement_render_attempts}/{MAX_CODE_GENERATION_RETRIES}"
+        msg += f":\n{render_context.frid_context.functional_requirement_text}\n"
+        msg += "-------------------------------------"
+        console.info(msg)
 
         try:
-            if render_context.verbose:
-                render_utils.print_inputs(
-                    render_context, existing_files_content, "Files sent as input to code generation:"
-                )
+            render_utils.print_inputs(render_context, existing_files_content, "Files sent as input to code generation:")
 
             response_files = render_context.codeplain_api.render_functional_requirement(
                 render_context.frid_context.frid,
@@ -73,12 +69,11 @@ class RenderFunctionalRequirement(BaseAction):
         )
         render_context.frid_context.changed_files.update(changed_files)
 
-        if render_context.verbose:
-            console.print_files(
-                "Files generated or updated:",
-                render_context.build_folder,
-                response_files,
-                style=console.OUTPUT_STYLE,
-            )
+        console.print_files(
+            "Files generated or updated:",
+            render_context.build_folder,
+            response_files,
+            style=console.OUTPUT_STYLE,
+        )
 
         return self.SUCCESSFUL_OUTCOME, None

--- a/render_machine/actions/run_conformance_tests.py
+++ b/render_machine/actions/run_conformance_tests.py
@@ -33,18 +33,16 @@ class RunConformanceTests(BaseAction):
                 )
             )
 
-        if render_context.verbose:
-            console.info(
-                f"Running conformance tests script {conformance_tests_script} "
-                + f"for {conformance_tests_folder_name} ("
-                + f"functionality {render_context.conformance_tests_running_context.current_testing_frid} "
-                + f"in module {render_context.conformance_tests_running_context.current_testing_module_name}"
-                + ")."
-            )
+        console.info(
+            f"Running conformance tests script {conformance_tests_script} "
+            + f"for {conformance_tests_folder_name} ("
+            + f"functionality {render_context.conformance_tests_running_context.current_testing_frid} "
+            + f"in module {render_context.conformance_tests_running_context.current_testing_module_name}"
+            + ")."
+        )
         exit_code, conformance_tests_issue, conformance_tests_temp_file_path = render_utils.execute_script(
             conformance_tests_script,
             [render_context.build_folder, conformance_tests_folder_name],
-            render_context.verbose,
             "Conformance Tests",
             frid=render_context.conformance_tests_running_context.current_testing_frid,
             module=render_context.conformance_tests_running_context.current_testing_module_name,

--- a/render_machine/actions/run_unit_tests.py
+++ b/render_machine/actions/run_unit_tests.py
@@ -18,14 +18,12 @@ class RunUnitTests(BaseAction):
     def execute(self, render_context: RenderContext, _previous_action_payload: Any | None):
         unittests_script = os.path.normpath(render_context.unittests_script)
 
-        if render_context.verbose:
-            console.info(
-                f"Running unit tests script {unittests_script}. (attempt: {render_context.unit_tests_running_context.fix_attempts + 1})"
-            )
+        console.info(
+            f"Running unit tests script {unittests_script}. (attempt: {render_context.unit_tests_running_context.fix_attempts + 1})"
+        )
         exit_code, unittests_issue, unittests_temp_file_path = render_utils.execute_script(
             unittests_script,
             [render_context.build_folder],
-            render_context.verbose,
             "Unit Tests",
             timeout=render_context.test_script_timeout,
             stop_event=render_context.stop_event,

--- a/render_machine/conformance_tests.py
+++ b/render_machine/conformance_tests.py
@@ -16,11 +16,9 @@ class ConformanceTests:
         self,
         conformance_tests_folder: str,
         conformance_tests_definition_file_name: str,
-        verbose: bool,
     ):
         self.conformance_tests_folder = conformance_tests_folder
         self.conformance_tests_definition_file_name = conformance_tests_definition_file_name
-        self.verbose = verbose
 
     def get_module_conformance_tests_folder(self, module_name: str) -> str:
         return os.path.join(self.conformance_tests_folder, module_name)
@@ -41,10 +39,9 @@ class ConformanceTests:
     def dump_conformance_tests_json(self, module_name: str, conformance_tests_json: dict) -> None:
         """Dump the conformance tests definition to the file."""
         if os.path.exists(self.get_module_conformance_tests_folder(module_name)):
-            if self.verbose:
-                console.debug(
-                    f"Storing conformance tests definition to {self._get_full_conformance_tests_definition_file_name(module_name)}"
-                )
+            console.debug(
+                f"Storing conformance tests definition to {self._get_full_conformance_tests_definition_file_name(module_name)}"
+            )
             with open(self._get_full_conformance_tests_definition_file_name(module_name), "w") as f:
                 json.dump(conformance_tests_json, f, indent=4)
 
@@ -140,13 +137,12 @@ class ConformanceTests:
             existing_conformance_test_files,
         )
 
-        if self.verbose:
-            console.print_files(
-                "Conformance test files fixed:",
-                current_conformance_test_folder_name,
-                response_files,
-                style=console.OUTPUT_STYLE,
-            )
+        console.print_files(
+            "Conformance test files fixed:",
+            current_conformance_test_folder_name,
+            response_files,
+            style=console.OUTPUT_STYLE,
+        )
 
     def fetch_existing_conformance_test_files(
         self,

--- a/render_machine/render_context.py
+++ b/render_machine/render_context.py
@@ -48,7 +48,6 @@ class RenderContext:
         render_range: list[str] | None,
         render_conformance_tests: bool,
         base_folder: str,
-        verbose: bool,
         run_state: RunState,
         event_bus: EventBus,
         test_script_timeout: Optional[int] = None,
@@ -74,7 +73,6 @@ class RenderContext:
         self.render_range = render_range
         self.render_conformance_tests = render_conformance_tests
         self.base_folder = base_folder
-        self.verbose = verbose
         self.run_state = run_state
         self.event_bus = event_bus
         self.stop_event = stop_event
@@ -99,7 +97,6 @@ class RenderContext:
         self.conformance_tests = ConformanceTests(
             conformance_tests_folder=self.conformance_tests_folder,
             conformance_tests_definition_file_name=CONFORMANCE_TESTS_DEFINITION_FILE_NAME,
-            verbose=verbose,
         )
 
         self.machine = None
@@ -334,10 +331,9 @@ class RenderContext:
         self.frid_context.refactoring_iteration += 1
 
         if self.frid_context.refactoring_iteration >= MAX_REFACTORING_ITERATIONS:
-            if self.verbose:
-                console.info(
-                    f"Refactoring iterations limit of {MAX_REFACTORING_ITERATIONS} reached for functionality {self.frid_context.frid}."
-                )
+            console.info(
+                f"Refactoring iterations limit of {MAX_REFACTORING_ITERATIONS} reached for functionality {self.frid_context.frid}."
+            )
             self.machine.dispatch(triggers.PROCEED_FRID_PROCESSING)
 
     def finish_refactoring_code(self):
@@ -440,8 +436,7 @@ class RenderContext:
         """Handle regeneration of conformance tests after too many failures."""
         ctx = self.conformance_tests_running_context
 
-        if self.verbose:
-            console.info(f"Recreating conformance tests for functionality {ctx.current_testing_frid}.")
+        console.info(f"Recreating conformance tests for functionality {ctx.current_testing_frid}.")
 
         existing_folder = ctx.get_conformance_tests_json(ctx.current_testing_module_name).pop(ctx.current_testing_frid)
         file_utils.delete_folder(existing_folder["folder_name"])
@@ -625,10 +620,7 @@ class RenderContext:
                 self.machine.dispatch(triggers.MARK_REGENERATION_OF_CONFORMANCE_TESTS)
 
     def finish_fixing_conformance_tests(self):
-        if self.verbose:
-            console.info(
-                f"Running conformance tests attempt {self.conformance_tests_running_context.fix_attempts + 1}."
-            )
+        console.info(f"Running conformance tests attempt {self.conformance_tests_running_context.fix_attempts + 1}.")
 
     def start_render_completed(self):
         self.run_state.set_render_succeeded(True)

--- a/render_machine/render_utils.py
+++ b/render_machine/render_utils.py
@@ -90,7 +90,6 @@ def _sanitize_script_output(script_output: str) -> str:
 def execute_script(  # noqa: C901
     script: str,
     scripts_args: list[str],
-    verbose: bool,
     script_type: str,
     frid: Optional[str] = None,
     module: Optional[str] = None,
@@ -166,60 +165,56 @@ def execute_script(  # noqa: C901
 
         sanitized_script_output = _sanitize_script_output(stdout)
 
-        # Log the info about the script execution
-        if verbose:
-            with tempfile.NamedTemporaryFile(
-                mode="w+", encoding="utf-8", delete=False, suffix=".script_output"
-            ) as temp_file:
-                temp_file.write(f"\n═════════════════════════ {script_type} Script Output ═════════════════════════\n")
-                temp_file.write(sanitized_script_output)
-                temp_file.write("\n══════════════════════════════════════════════════════════════════════\n")
-                temp_file_path = temp_file.name
-                if proc.returncode != 0:
-                    temp_file.write(f"{script_type} script {script} failed with exit code {proc.returncode}.\n")
-                else:
-                    temp_file.write(f"{script_type} script {script} successfully passed.\n")
-                temp_file.write(f"{script_type} script execution time: {elapsed_time:.2f} seconds.\n")
-
-            console.debug(f"[#888888]{script_type} script output stored in: {temp_file_path.strip()}[/#888888]")
-
+        with tempfile.NamedTemporaryFile(
+            mode="w+", encoding="utf-8", delete=False, suffix=".script_output"
+        ) as temp_file:
+            temp_file.write(f"\n═════════════════════════ {script_type} Script Output ═════════════════════════\n")
+            temp_file.write(sanitized_script_output)
+            temp_file.write("\n══════════════════════════════════════════════════════════════════════\n")
+            temp_file_path = temp_file.name
             if proc.returncode != 0:
-                if frid is not None:
-                    console.debug(
-                        f"The {script_type} script for functionality ID {frid} of module {module} has failed. Initiating the patching mode to automatically correct the discrepancies."
-                    )
-                else:
-                    console.debug(
-                        f"The {script_type} script has failed. Initiating the patching mode to automatically correct the discrepancies."
-                    )
+                temp_file.write(f"{script_type} script {script} failed with exit code {proc.returncode}.\n")
             else:
-                if frid is not None:
-                    console.info(
-                        f"[#79FC96]The {script_type} script for functionality ID {frid} of module {module} has passed successfully.[/#79FC96]"
-                    )
-                else:
-                    console.info(f"[#79FC96]All {script_type} scripts have passed successfully.[/#79FC96]")
+                temp_file.write(f"{script_type} script {script} successfully passed.\n")
+            temp_file.write(f"{script_type} script execution time: {elapsed_time:.2f} seconds.\n")
+
+        console.debug(f"[#888888]{script_type} script output stored in: {temp_file_path.strip()}[/#888888]")
+
+        if proc.returncode != 0:
+            if frid is not None:
+                console.debug(
+                    f"The {script_type} script for functionality ID {frid} of module {module} has failed. Initiating the patching mode to automatically correct the discrepancies."
+                )
+            else:
+                console.debug(
+                    f"The {script_type} script has failed. Initiating the patching mode to automatically correct the discrepancies."
+                )
+        else:
+            if frid is not None:
+                console.info(
+                    f"[#79FC96]The {script_type} script for functionality ID {frid} of module {module} has passed successfully.[/#79FC96]"
+                )
+            else:
+                console.info(f"[#79FC96]All {script_type} scripts have passed successfully.[/#79FC96]")
 
         return proc.returncode, sanitized_script_output, temp_file_path
 
     except RenderCancelledError:
         raise
     except subprocess.TimeoutExpired as e:
-        # Store timeout output in a temporary file
-        if verbose:
-            with tempfile.NamedTemporaryFile(
-                mode="w+", encoding="utf-8", delete=False, suffix=".script_timeout"
-            ) as temp_file:
-                temp_file.write(f"{script_type} script {script} timed out after {script_timeout} seconds.")
-                if e.stdout:
-                    decoded_output = e.stdout.decode("utf-8") if isinstance(e.stdout, bytes) else e.stdout
-                    temp_file.write(f"{script_type} script partial output before the timeout:\n{decoded_output}")
-                else:
-                    temp_file.write(f"{script_type} script did not produce any output before the timeout.")
-                temp_file_path = temp_file.name
-            console.warning(
-                f"The {script_type} script timed out after {script_timeout} seconds. {script_type} script output stored in: {temp_file_path}"
-            )
+        with tempfile.NamedTemporaryFile(
+            mode="w+", encoding="utf-8", delete=False, suffix=".script_timeout"
+        ) as temp_file:
+            temp_file.write(f"{script_type} script {script} timed out after {script_timeout} seconds.")
+            if e.stdout:
+                decoded_output = e.stdout.decode("utf-8") if isinstance(e.stdout, bytes) else e.stdout
+                temp_file.write(f"{script_type} script partial output before the timeout:\n{decoded_output}")
+            else:
+                temp_file.write(f"{script_type} script did not produce any output before the timeout.")
+            temp_file_path = temp_file.name
+        console.warning(
+            f"The {script_type} script timed out after {script_timeout} seconds. {script_type} script output stored in: {temp_file_path}"
+        )
 
         partial_output = ""
         if e.stdout:

--- a/tui/plain2code_tui.py
+++ b/tui/plain2code_tui.py
@@ -70,6 +70,7 @@ class Plain2CodeTUI(App):
         prepare_environment_script: str,
         state_machine_version: str,
         enter_pause_event: threading.Event | None = None,
+        default_log_level: str = "INFO",
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -82,6 +83,7 @@ class Plain2CodeTUI(App):
         self.prepare_environment_script: Optional[str] = prepare_environment_script
         self.state_machine_version = state_machine_version
         self.enter_pause_event = enter_pause_event
+        self.default_log_level = default_log_level
         self._render_finished = False
 
         # Initialize state handlers
@@ -119,6 +121,15 @@ class Plain2CodeTUI(App):
         self.event_bus.subscribe(RenderModuleFailed, self.on_render_module_failed)
         self.event_bus.subscribe(LogMessageEmitted, self.on_log_message_emitted)
         self.event_bus.subscribe(RenderPaused, self.on_render_paused)
+
+        if self.default_log_level != "INFO":
+            try:
+                log_widget = self.query_one(f"#{TUIComponents.LOG_WIDGET.value}", StructuredLogView)
+                log_widget.min_level = self.default_log_level
+                log_filter = self.query_one(f"#{TUIComponents.LOG_FILTER.value}", LogLevelFilter)
+                log_filter._update_level(self.default_log_level)
+            except NoMatches:
+                pass
 
         self._on_ready()
 


### PR DESCRIPTION
## Summary
- Repurpose `--verbose` from an always-on no-op (`default=True`) to an opt-in flag (`default=False`) that sets the default log level to DEBUG for TUI and file logs
- Remove all `if verbose:` guards — debug messages are always emitted, log-level filtering decides visibility
- `logging_config.yaml` takes precedence over `--verbose` when present
- TUI default filter starts at DEBUG when `--verbose` is set
- Remove unused `codeplainAPI.verbose`, `RenderContext.verbose`, and `ConformanceTests.verbose` attributes

Closes https://github.com/Codeplain-ai/next-microsoft/issues/75

## Test plan
- [x] All 125 tests pass
- [x] black, isort, flake8, mypy all pass
- [x] Manual test: render without `--verbose` → log file contains INFO only, TUI shows INFO by default
- [x] Manual test: render with `--verbose` → log file contains DEBUG, TUI defaults to DEBUG filter
- [x] Manual test: with `logging_config.yaml` present, its settings override `--verbose`