### PR TITLE
Add "rendering canceled" post render output

### DIFF
--- a/cli_output/render_summary.py
+++ b/cli_output/render_summary.py
@@ -15,7 +15,12 @@ def print_exit_summary(
     """Print render outcome after the TUI exits (terminal restored)."""
     console.quiet = False
 
-    msg = "\n[#79FC96]✓ rendering completed\n\n" if run_state.render_succeeded else "[#FF6B6B]✗ rendering failed\n\n"
+    if run_state.render_succeeded:
+        msg = "\n[#79FC96]✓ rendering completed\n\n"
+    elif run_state.render_cancelled:
+        msg = "\n[#FFFFFF]— rendering canceled\n\n"
+    else:
+        msg = "\n[#FF6B6B]✗ rendering failed\n\n"
     msg += f"  [#8E8F91]render id:\t\t\t[#FFFFFF]{run_state.render_id}\n"
     msg += f"  [#8E8F91]input file:\t\t\t[#FFFFFF]{spec_filename}\n"
     msg += f"  [#8E8F91]generated code folder:\t[#FFFFFF]{run_state.render_generated_code_path or '-'}\n\n"

--- a/plain2code.py
+++ b/plain2code.py
@@ -181,6 +181,7 @@ def render(args, run_state: RunState, event_bus: EventBus, default_log_level: st
                     render_choices,
                     system_config.client_version,
                     run_state.render_id,
+                    on_cancel=run_state.set_render_cancelled,
                     css_path="styles.css",
                 )
                 render_choice = app.run()
@@ -189,6 +190,7 @@ def render(args, run_state: RunState, event_bus: EventBus, default_log_level: st
                     and render_choice.render_range is None
                     and render_choice.choice_type == "quit"
                 ):
+                    run_state.set_render_cancelled()
                     sys.exit(0)
             elif ask_user and args.headless:
                 # ignore the default choice if it requires user input due to headless mode
@@ -217,7 +219,7 @@ def render(args, run_state: RunState, event_bus: EventBus, default_log_level: st
         try:
             module_renderer.render_module()
         except RenderCancelledError:
-            pass  # TUI already closed, nothing to report
+            run_state.set_render_cancelled()  # TUI already closed, nothing to report
         except Exception as e:
             run_state.set_render_succeeded(False)
             render_error.append(e)
@@ -228,8 +230,7 @@ def render(args, run_state: RunState, event_bus: EventBus, default_log_level: st
         try:
             module_renderer.render_module()
         except RenderCancelledError:
-            run_state.set_render_succeeded(False)
-            pass
+            run_state.set_render_cancelled()
         return
     else:
         render_thread = threading.Thread(target=run_render, daemon=True)
@@ -242,6 +243,7 @@ def render(args, run_state: RunState, event_bus: EventBus, default_log_level: st
             prepare_environment_script=args.prepare_environment_script,
             state_machine_version=system_config.client_version,
             enter_pause_event=enter_pause_event,
+            on_cancel=run_state.set_render_cancelled,
             default_log_level=default_log_level,
             css_path="styles.css",
         )

--- a/plain2code_state.py
+++ b/plain2code_state.py
@@ -11,6 +11,7 @@ class RunState:
     def __init__(self, spec_filename: str, replay_with: Optional[str] = None):
         self.replay: bool = replay_with is not None
         self.render_succeeded: bool = False
+        self.render_cancelled: bool = False
         self.render_generated_code_path: Optional[str] = None
         self.rendered_functionalities: int = 0
         if replay_with:
@@ -35,6 +36,9 @@ class RunState:
 
     def set_render_succeeded(self, succeeded: bool):
         self.render_succeeded = succeeded
+
+    def set_render_cancelled(self):
+        self.render_cancelled = True
 
     def set_render_generated_code_path(self, generated_code_path: str):
         self.render_generated_code_path = generated_code_path

--- a/tui/plain2code_tui.py
+++ b/tui/plain2code_tui.py
@@ -70,6 +70,7 @@ class Plain2CodeTUI(App):
         prepare_environment_script: str,
         state_machine_version: str,
         enter_pause_event: threading.Event | None = None,
+        on_cancel: Callable[[], None] | None = None,
         default_log_level: str = "INFO",
         **kwargs,
     ):
@@ -83,6 +84,7 @@ class Plain2CodeTUI(App):
         self.prepare_environment_script: Optional[str] = prepare_environment_script
         self.state_machine_version = state_machine_version
         self.enter_pause_event = enter_pause_event
+        self._on_cancel = on_cancel
         self.default_log_level = default_log_level
         self._render_finished = False
 
@@ -311,4 +313,6 @@ class Plain2CodeTUI(App):
         Note: Force exit may leave files partially written if interrupted during file I/O operations.
         This is acceptable since the folders in which we are writing are git versioned and are reset in the next render.
         """
+        if not self._render_finished and self._on_cancel:
+            self._on_cancel()
         self.exit()

--- a/tui/plain_module_render_choice_tui.py
+++ b/tui/plain_module_render_choice_tui.py
@@ -1,3 +1,5 @@
+from typing import Callable, Optional
+
 from textual import on
 from textual.app import App, ComposeResult
 from textual.binding import Binding
@@ -24,6 +26,7 @@ class PlainModuleRenderChoiceTUI(App):
         render_choices: dict[str, RenderChoice],
         state_machine_version: str,
         render_id: str,
+        on_cancel: Optional[Callable[[], None]] = None,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -33,6 +36,7 @@ class PlainModuleRenderChoiceTUI(App):
         self.render_id = render_id
         self._expandable_labels: list[dict] = []
         self.render_choices = render_choices
+        self._on_cancel = on_cancel
 
     def get_msg_from_choice(self, render_choice: RenderChoice) -> str:
         if render_choice.choice_type == "module_start":
@@ -190,6 +194,11 @@ class PlainModuleRenderChoiceTUI(App):
     def _select_choice(self, key: str) -> None:
         self.selected_choice = self.render_choices[key]
         self.exit(self.selected_choice)
+
+    def action_quit(self) -> None:
+        if self._on_cancel:
+            self._on_cancel()
+        self.exit()
 
     async def action_copy_selection(self) -> None:
         """Handle ctrl+c: copy selected text if any.


### PR DESCRIPTION
Until now it said "rendering failed" if the user canceled rendering.

<img width="1092" height="322" alt="image" src="https://github.com/user-attachments/assets/8169b75f-74d6-40cf-bff3-8c8fd47c74f7" />

- [ ] check what happens if you cancel during the partial rendering step