### PR TITLE
show friendly error when git is not installed

### DIFF
--- a/plain2code.py
+++ b/plain2code.py
@@ -25,6 +25,7 @@ from plain2code_console import console
 from plain2code_events import RenderFailed
 from plain2code_exceptions import (
     ConflictingRequirements,
+    GitNotInstalledError,
     InvalidAPIKey,
     InvalidFridArgument,
     MissingAPIKey,
@@ -356,6 +357,7 @@ def main():  # noqa: C901
                     NetworkConnectionError,
                     ModuleDoesNotExistError,
                     UnsupportedResourceType,
+                    GitNotInstalledError,
                 ),
             ):
                 exc_info = sys.exc_info()

--- a/plain2code_exceptions.py
+++ b/plain2code_exceptions.py
@@ -89,3 +89,9 @@ class RenderCancelledError(Exception):
     """Raised when the render is cancelled by the user closing the TUI."""
 
     pass
+
+
+class GitNotInstalledError(Exception):
+    """Raised when git is not installed or not found on PATH."""
+
+    pass

--- a/plain_modules.py
+++ b/plain_modules.py
@@ -5,13 +5,17 @@ import os
 import shutil
 from functools import cached_property
 
-from git.exc import NoSuchPathError
+from plain2code_exceptions import GitNotInstalledError, MissingPreviousFunctionalitiesError, ModuleDoesNotExistError
+
+try:
+    from git.exc import NoSuchPathError
+except ImportError:
+    raise GitNotInstalledError("git is not installed. Please install git and try again.")
 
 import git_utils
 import plain_file
 import plain_spec
 from plain2code_console import console
-from plain2code_exceptions import MissingPreviousFunctionalitiesError, ModuleDoesNotExistError
 from render_machine.implementation_code_helpers import ImplementationCodeHelpers
 
 CODEPLAIN_MEMORY_SUBFOLDER = ".memory"


### PR DESCRIPTION
Without git on PATH, gitpython crashes at import time with a cryptic traceback. Catch the ImportError and print a clear message instead.

Tested in a docker container that has no git by copying over my local code to the container.

https://github.com/Codeplain-ai/codeplain/issues/133

