### PR TITLE
fix test which fails since today

### DIFF
--- a/tests/test_cli_output.py
+++ b/tests/test_cli_output.py
@@ -198,7 +198,7 @@ class TestDisplayStatusMessage:
         purchased_credits = [
             {
                 "remaining": 20,
-                "expiry_date": "2026-06-12T00:00:00+00:00",
+                "expiry_date": "2030-06-12T00:00:00+00:00",
             }
         ]
         _display_status_message(None, purchased_credits)


### PR DESCRIPTION
This is a lazy fix.

But I'll add a ticket to fix system date for such tests to prevent failing tests because of future dates not being in the future anymore.