### PR TITLE
fix: relax python version req

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "codeplain"
 dynamic = ["version"]
 description = "Transform plain language specifications into working code"
 readme = "README.md"
-requires-python = "==3.11"
+requires-python = "==3.11.*"
 classifiers = [
     "Environment :: Console",
     "Intended Audience :: Developers",


### PR DESCRIPTION
Relax python version requirement to allow latest patch version (via uv run).

Could probably go further with "~=3.11" allowing for higher minor versions like 3.14...