### PR TITLE
Method Not Allowed - redirect following bug

### DIFF
--- a/codeplain_REST_api.py
+++ b/codeplain_REST_api.py
@@ -130,7 +130,14 @@ class CodeplainAPI:
 
         for attempt in range(num_retries + 1):
             try:
-                response = requests.post(endpoint_url, headers=headers, json=payload)
+                response = requests.post(endpoint_url, headers=headers, json=payload, allow_redirects=False)
+
+                if 300 <= response.status_code < 400:
+                    # Treat redirects as a retryable error so a transient redirect retries as a real POST.
+                    raise RequestException(
+                        f"Unexpected redirect ({response.status_code}) to "
+                        f"{response.headers.get('Location')} from {endpoint_url}"
+                    )
 
                 try:
                     response_json = response.json()


### PR DESCRIPTION
Addressing these Sentry errors:
https://codeplain.sentry.io/issues/7407243122/?project=4510794036674560&query=is%3Aunresolved&referrer=issue-stream
https://codeplain.sentry.io/issues/7229526782/events/recommended/?project=4510794036674560&query=user.ip%3A%2262.4.40.218%22&referrer=issue-stream

We are seeing rare server-side errors at some API calls:
`405 Method Not Allowed: The method is not allowed for the requested URL.`

The 405 for a POST-only call generally means it was redirected and downgraded to a GET request.
The client always sends POST, so a 405 on a POST-only route means the request reached the router as a non-POST which isn't allowed causing the crash. The redirect happens cause of App Engine not directly our server code.

It happens very rarely and currently  most often on create_conformance_test_memory because that endpoint carries a large request body (two full test outputs) which may be why it mostly happens here but this payload is still relatively small. I can look into reducing this anyway.

The fix:
- Added allow_redirects=False and an explicit 3xx check that checks for a redirect and raises a retryable error. This protects endpoints against this behavior.
