### PR TITLE
Adjusted the FunctionalRequirementTooComplex output on the client to avoid duplication

### DIFF
--- a/render_machine/actions/render_functional_requirement.py
+++ b/render_machine/actions/render_functional_requirement.py
@@ -48,7 +48,7 @@ class RenderFunctionalRequirement(BaseAction):
                 render_context.run_state,
             )
         except FunctionalRequirementTooComplex as e:
-            error_message = f"The functionality:\n{render_context.frid_context.functional_requirement_text}\n is too complex to be implemented. Please break down the functionality into smaller parts ({str(e)})."
+            error_message = f"The functionality:\n{render_context.frid_context.functional_requirement_text}\n is too complex to be implemented. Please break down the functionality into smaller parts."
             if e.proposed_breakdown:
                 error_message += "\nProposed breakdown:"
                 for _, part in e.proposed_breakdown["functional_requirements"].items():


### PR DESCRIPTION
When hitting the FunctionalRequirementTooComplex issue, the "too complex" functionality was printed out twice in a suboptimal format. 

This PR adjusts the output so it is cleaner.