### PR TITLE
Write rendered files as UTF-8 to fix Windows UnicodeEncodeError

### DIFF
--- a/file_utils.py
+++ b/file_utils.py
@@ -157,7 +157,7 @@ def store_response_files(target_folder, response_files, existing_files):
 
         os.makedirs(os.path.dirname(full_file_name), exist_ok=True)
 
-        with open(full_file_name, "w") as f:
+        with open(full_file_name, "w", encoding="utf-8") as f:
             f.write(response_files[file_name])
 
         if file_name not in existing_files:

--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -3,7 +3,7 @@ import tempfile
 
 import pytest
 
-from file_utils import load_linked_resources
+from file_utils import load_linked_resources, store_response_files
 from plain2code_exceptions import UnsupportedResourceType
 
 
@@ -39,3 +39,14 @@ def test_load_linked_resources_binary_file_raises_unsupported_resource_type(temp
 def test_load_linked_resources_missing_file_raises_file_not_found(template_dir):
     with pytest.raises(FileNotFoundError):
         load_linked_resources([template_dir], [{"text": "Missing", "target": "missing.md"}], "my_thing")
+
+
+def test_store_response_files_writes_unicode_as_utf8(template_dir):
+    # Content with a non-cp1252 character (📍 U+1F4CD) must be written as UTF-8
+    # regardless of the platform's default text encoding (e.g. cp1252 on Windows).
+    content = "Location 📍 marker"
+    store_response_files(template_dir, {"notes.md": content}, [])
+
+    file_path = os.path.join(template_dir, "notes.md")
+    with open(file_path, "rb") as f:
+        assert f.read().decode("utf-8") == content


### PR DESCRIPTION
store_response_files opened files with the platform default text codec, which on Windows is cp1252 and cannot encode characters like 📍 (U+1F4CD). LLM-generated content containing such characters crashed the render with UnicodeEncodeError. Specify encoding="utf-8" explicitly, matching how the rest of file_utils reads text. Add a regression test covering unicode content.

Fixes CODEPLAIN-P

https://codeplain.sentry.io/issues/7563551370/?project=4511540621213696&query=is%3Aunresolved&referrer=issue-stream