### PR TITLE
fix(error): propagate render error message to TUI

### DIFF
--- a/module_renderer.py
+++ b/module_renderer.py
@@ -132,7 +132,7 @@ class ModuleRenderer:
         code_renderer.run()
         if code_renderer.render_context.state == States.RENDER_FAILED.value:
             error_message = RenderError.get_display_message(
-                code_renderer.render_context.previous_action_payload,
+                code_renderer.render_context.last_error_message,
                 fallback_message=code_renderer.render_context.last_error_message,
             )
             code_renderer.render_context.event_bus.publish(RenderFailed(error_message=error_message))


### PR DESCRIPTION
## Summary
- pass the render context's last error message into RenderError.get_display_message()
- ensure the TUI receives the actual render failure message instead of the previous action payload

## Testing
- not run; PR created from existing commit