### PR TITLE
fix: suppress duplicate error output before logging setup

### DIFF
--- a/plain2code_logger.py
+++ b/plain2code_logger.py
@@ -9,6 +9,13 @@ from plain2code_state import RunState
 
 LOGGER_NAME = "codeplain"
 
+# Attach a NullHandler so that log records emitted before setup_logging() configures
+# the real handlers (e.g. during --dry-run, --status, --full-plain, or early parse
+# errors) are not printed to stderr by logging.lastResort. Without this, console.error()
+# / console.warning() — which both log the message and print it via rich — would show the
+# same message twice: once in plain text (from lastResort) and once styled (from rich).
+logging.getLogger(LOGGER_NAME).addHandler(logging.NullHandler())
+
 
 class IndentedFormatter(logging.Formatter):
     def format(self, record):


### PR DESCRIPTION
## Problem

Following #214, the linked-resource validation error (e.g. `Plain syntax error: Link ... does not exist.`) was printed **twice** during `--dry-run` — once in plain white text, then again in red.

## Root cause

`console.error()` in `plain2code_console.py` both logs the message (`logger.error(...)`) **and** rich-prints it in red. On `--dry-run` (and `--status`, `--full-plain`, and early parse errors), the module is parsed *before* `setup_logging()` configures any handlers. With no handler attached to the `codeplain` logger, Python's `logging.lastResort` handler echoes the `logger.error(...)` record to stderr as plain white text — so the same message appears twice (white from `lastResort`, red from rich).

## Fix

Attach a `NullHandler` to the `codeplain` logger at import time (the standard Python library idiom). This suppresses `lastResort` so records emitted before real handlers exist aren't echoed to stderr, leaving exactly one output on these pre-logging CLI paths. Once `setup_logging()` runs, the real handlers work as before.

This also fixes the same latent double-print for any other pre-logging `console.error`/`console.warning` call (`--status`, `--full-plain`).