### PR TITLE
Rewrite README as a getting started guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,19 +2,15 @@
 
 ## What is \*codeplain?
 
-\*codeplain makes coding agents better by having them write and maintain specifications instead of code. It extends coding agents with agentic skills for working at the specification layer, and with tools that convert specifications into tested and validated implementation code — this repository is the renderer that powers that last step, turning \*\*\*plain specs into software using the Codeplain API. The result is a software development workflow centered on specifications, which are faster and more efficient for AI to produce and easier for developers to review and maintain than raw code.
+\*codeplain makes coding agents better by having them write and maintain specifications instead of code. It extends coding agents with agentic skills for working at the specification layer, and with tools that convert specifications into tested and validated implementation code.
+
+This repository is the renderer that powers that last step, turning \*\*\*plain specs into software using the *codeplain API.
+
+The result is a software development workflow centered on specifications, which are faster and more efficient for AI to produce and easier for developers to review and maintain than raw code.
 
 Schematic overview of the *codeplain's code rendering:
 
 <img src="https://raw.githubusercontent.com/Codeplain-ai/plain2code_client/main/resources/codeplain_overview.png">
-
-### Abstracting Away Code Generation Complexity with \*\*\*plain
-
-\*\*\*plain is a novel specification language that helps abstracting away complexity of using large language models for code generation.
-
-An example application in \*\*\*plain
-
-<img src="resources/plain_example.png" width="70%" height="70%">
 
 ## Getting started
 
@@ -88,6 +84,20 @@ If you're using Visual Studio Code or Cursor IDE, we also recommend installing t
 Share what you're building! Join the [\*codeplain Discord](https://discord.gg/cgbynb9hFq) if you have questions, ideas, or want to share what you built.
 
 Hit an edge case or have feedback? Reach us at [support@codeplain.ai](mailto:support@codeplain.ai).
+
+## Abstracting Away Code Generation Complexity with \*\*\*plain
+
+\*\*\*plain is the language of spec-driven development — a specification language that combines the efficiency of natural language with the control and precision of code.
+
+Structured sections for definitions, functional specs, implementation requirements, test requirements, and acceptance tests let your specs (not scattered docs or ad hoc prompts) become the source of truth for your software's behavior, abstracting away the complexity of using large language models for code generation.
+
+Specs are plain text, so they fit into the workflows you already use — version control, pull requests, and code review.
+
+See the [\*\*\*plain language guide](https://www.plainlang.org/docs/language-guide/) to learn the full syntax.
+
+An example application in \*\*\*plain
+
+<img src="resources/plain_example.png" width="70%" height="70%">
 
 ## Additional Resources
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,10 @@
-# Codeplain plain2code renderer
+# *codeplain renderer
 
-Render \*\*\*plain source to software code using the Codeplain API.
+## What is \*codeplain?
 
-## Codeplain.ai - Code Generation as a Service
+\*codeplain makes coding agents better by having them write and maintain specifications instead of code. It extends coding agents with agentic skills for working at the specification layer, and with tools that convert specifications into tested and validated implementation code — this repository is the renderer that powers that last step, turning \*\*\*plain specs into software using the Codeplain API. The result is a software development workflow centered on specifications, which are faster and more efficient for AI to produce and easier for developers to review and maintain than raw code.
 
-Codeplain is a platform that generates software code using large language models based on requirements you specify in \*\*\*plain specification language.
-
-Schematic overview of the Codeplain's code generation service
+Schematic overview of the *codeplain's code rendering:
 
 <img src="https://raw.githubusercontent.com/Codeplain-ai/plain2code_client/main/resources/codeplain_overview.png">
 
@@ -20,100 +18,85 @@ An example application in \*\*\*plain
 
 ## Getting started
 
-### Prerequisites
+Get started in 15 minutes.
 
-#### System requirements
+### 1. Install \*codeplain in the terminal
 
-To run the plain2code client, you need Python 3.11 or a later version.
+macOS and Linux:
+
+```bash
+curl -fsSL https://codeplain.ai/install.sh | bash
+```
+
+Windows PowerShell:
+
+```powershell
+irm https://codeplain.ai/install.ps1 | iex
+```
 
 **Windows users:** Please install WSL (Windows Subsystem for Linux) as this is currently the supported environment for running plain code on Windows.
 
-#### Authorization - Codeplain API Key
+Follow the installation instructions to complete setup. The installer installs the `codeplain` CLI and walks you through setting your `CODEPLAIN_API_KEY`.
 
-We are using Codeplain API Key to authorize requests to the Codeplain API. To get your Codeplain API Key, please contact Codeplain.ai support at support@codeplain.ai.
-
-In order to generate code, you need to export the following environment variable:
+If you'd rather not run the installer, sign up at [platform.codeplain.ai](https://platform.codeplain.ai) to get your API key and export it yourself:
 
 ```bash
 export CODEPLAIN_API_KEY="your_actual_api_key_here"
 ```
 
-### Installation Steps
+### 2. Let your agent work in specs, not code
 
-1. Clone this repository
-2. Set your Codeplain API key as an environment variable:
-   ```
-   export CODEPLAIN_API_KEY=your_api_key_here
-   ```
-3. (Recommended) Create and activate a virtual environment:
-   ```bash
-   python -m venv .venv
-   source .venv/bin/activate
-   ```
-4. Install required libraries
-   ```
-   pip install -r requirements.txt
-   ```
+You describe what you want in plain English, an agent helps you write a spec in \*\*\*plain language, and \*codeplain renders the actual code.
 
-### Quick Start
+```bash
+npx plain-forge install
+```
 
-After completing the installation steps above, you can immediately test the system with a simple "Hello World" example:
+### 3. Convert specs into tested and validated code
+
+\*codeplain extends coding agents with agentic skills for working at the specification layer, and with tools that convert specifications into tested and validated implementation code.
+
+```bash
+codeplain your-project.plain
+```
+
+### Try it now
+
+You can immediately test the system with a simple "Hello World" example:
 
 - Change to the example folder and run the example:
 
-  ```
+  ```bash
   cd examples/example_hello_world_python
-  python ../../plain2code.py hello_world_python.plain
+  codeplain hello_world_python.plain
   ```
 
   _Note: Rendering will take a few minutes to complete._
 
 - The system will generate a Python application in the `build` directory. You can run it with:
-  ```
+  ```bash
   cd build
   python hello_world.py
   ```
 
-### Crash reporting
+### VS Code / Cursor extension
 
-If the plain2code client crashes unexpectedly, it sends an anonymous crash report to Codeplain to help improve the tool. To disable crash reporting, set the `CODEPLAIN_NO_TELEMETRY=1` flag.
+If you're using Visual Studio Code or Cursor IDE, we also recommend installing the [plyn extension](https://marketplace.visualstudio.com/items?itemName=Codeplain.plyn).
 
+### Community and support
 
-## Releasing
+Share what you're building! Join the [\*codeplain Discord](https://discord.gg/cgbynb9hFq) if you have questions, ideas, or want to share what you built.
 
-Releases are built and published with [uv](https://docs.astral.sh/uv/). The version is read from `_version.py`.
-
-1. Bump the version in `_version.py`, commit it and create new tag (`git tag v<version>`).
-2. Build the distributions:
-   ```bash
-   uv build --python 3.11
-   ```
-   This produces `dist/codeplain-<version>-py3-none-any.whl` and `dist/codeplain-<version>.tar.gz`.
-3. (Optional) Smoke-test the wheel:
-   ```bash
-   uv run --with dist/codeplain-<version>-py3-none-any.whl --no-project -- codeplain --status
-   ```
-4. (Optional) Publish to TestPyPI first:
-   ```bash
-   uv publish --publish-url https://test.pypi.org/legacy/ dist/codeplain-<version>*
-   ```
-5. Publish to PyPI:
-   ```bash
-   uv publish dist/codeplain-<version>*
-   ```
-   Authenticate with `UV_PUBLISH_TOKEN=pypi-...` (recommended), `--token pypi-...`, or `--username __token__ --password pypi-...`.
-6. Push the `main` branch (with version commit) and push the tag: `git push origin v<version>`.
+Hit an edge case or have feedback? Reach us at [support@codeplain.ai](mailto:support@codeplain.ai).
 
 ## Additional Resources
 
 ### Examples and Sample Projects
 
-- See the [examples](examples) folder for sample projects in Golang, Python, and React.
-- For example application how to implement task manager in \*\*\*plain see [example-task-manager](https://github.com/Codeplain-ai/example-task-manager) repository.
-- For example application how to implement SaaS connectors in \*\*\*plain see [example-saas-connectors](https://github.com/Codeplain-ai/example-saas-connectors) repository.
+- See the [examples](examples) folder for sample projects in Golang, Python, React, and Flutter.
+- For an example of how to implement Pong in \*\*\*plain, see the [pong](https://github.com/Codeplain-ai/plainlang-examples/tree/main/pong) example.
+- For an example of how to implement a task manager in \*\*\*plain, see the [task-manager](https://github.com/Codeplain-ai/plainlang-examples/tree/main/task-manager) example.
 
 ### Documentation
 
 - For more details on the ***plain format, see the [***plain language specification](https://www.plainlang.org/docs/).
-- For step-by-step instructions for creating your first ***plain project see the [Kickstart your ***plain project](docs/starting_a_plain_project_from_scratch.md).
-- For complete CLI documentation and usage examples, see [plain2code CLI documentation](docs/plain2code_cli.md).

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## What is \*codeplain?
 
-\*codeplain makes coding agents better by having them write and maintain specifications instead of code. It extends coding agents with agentic skills for working at the specification layer, and with tools that convert specifications into tested and validated implementation code.
+\*codeplain platform makes coding agents better by having them write and maintain specifications instead of code. It extends coding agents with agentic skills for working at the specification layer, and with tools that convert specifications into tested and validated implementation code.
 
 This repository is the renderer that powers that last step, turning \*\*\*plain specs into software using the *codeplain API.
 
@@ -32,7 +32,7 @@ irm https://codeplain.ai/install.ps1 | iex
 
 **Windows users:** Please install WSL (Windows Subsystem for Linux) as this is currently the supported environment for running plain code on Windows.
 
-Follow the installation instructions to complete setup. The installer installs the `codeplain` CLI and walks you through setting your `CODEPLAIN_API_KEY`.
+Follow the installation instructions to complete setup. The installer installs the `codeplain` CLI, walks you through setting your `CODEPLAIN_API_KEY`, and offers to set up [plain-forge](#2-let-your-agent-work-in-specs-not-code) and the [plyn editor extension](#vs-code--cursor-extension) for you in the same session.
 
 If you'd rather not run the installer, sign up at [platform.codeplain.ai](https://platform.codeplain.ai) to get your API key and export it yourself:
 
@@ -42,7 +42,9 @@ export CODEPLAIN_API_KEY="your_actual_api_key_here"
 
 ### 2. Let your agent work in specs, not code
 
-You describe what you want in plain English, an agent helps you write a spec in \*\*\*plain language, and \*codeplain renders the actual code.
+You describe what you want in plain English, an agent helps you write a spec in \*\*\*plain language, and \*codeplain renders the actual code. This is what [plain-forge](https://github.com/Codeplain-ai/plain-forge) sets up: a toolkit of skills, rules, and docs that plugs into your AI coding agent of choice — Claude Code, Codex, ForgeCode, OpenCode, or any other agent that reads from a standard skills directory — and turns a conversation into a complete `.plain` spec, then keeps maintaining it across the lifetime of the project.
+
+If you didn't install it during step 1, run it any time:
 
 ```bash
 npx plain-forge install
@@ -77,7 +79,7 @@ You can immediately test the system with a simple "Hello World" example:
 
 ### VS Code / Cursor extension
 
-If you're using Visual Studio Code or Cursor IDE, we also recommend installing the [plyn extension](https://marketplace.visualstudio.com/items?itemName=Codeplain.plyn).
+If you're using Visual Studio Code or Cursor IDE, we also recommend installing the [plyn extension](https://marketplace.visualstudio.com/items?itemName=Codeplain.plyn) for `***plain` syntax highlighting. The installer in step 1 offers to install it automatically if it detects `code` or `cursor` on your `PATH`.
 
 ### Community and support
 


### PR DESCRIPTION
## Summary
- Replace the outdated clone + `pip install -r requirements.txt` flow with the current `curl .../install.sh` / `irm .../install.ps1` installer (matches `install/bash/install.sh` and the `codeplain` CLI entry point).
- Restructure Getting Started as a 3-step guide: install the CLI, install agent skills (`npx plain-forge install`), then render specs (`codeplain your-project.plain`).
- Refresh the intro copy to describe *codeplain as a spec-centric platform for coding agents, not just a code renderer.
- Add VS Code/Cursor extension, Discord, and support links; drop the stale "Releasing" (maintainer-only) and doc links that pointed to removed pages.
- Update example links to the `pong` and `task-manager` examples in `plainlang-examples`, and add Flutter to the sample-project languages list.
