### PR TITLE
Verify the API key when pasted during install (next-microsoft#27)

### DIFF
--- a/install/bash/install.sh
+++ b/install/bash/install.sh
@@ -102,10 +102,11 @@ fi
 
 # Check if API key already exists
 SKIP_API_KEY_SETUP=false
+API_KEY_VERIFIED=false
 if [ -n "${CODEPLAIN_API_KEY:-}" ]; then
+    USE_EXISTING=false
     if [ "$NONINTERACTIVE" = "1" ]; then
-        echo -e "${GREEN}✓${NC} Using existing CODEPLAIN_API_KEY (non-interactive mode)."
-        SKIP_API_KEY_SETUP=true
+        USE_EXISTING=true
     else
         echo -e "  You already have an API key configured."
         echo ""
@@ -115,7 +116,32 @@ if [ -n "${CODEPLAIN_API_KEY:-}" ]; then
         echo ""
 
         if [[ ! "$GET_NEW_KEY" =~ ^[Yy]$ ]]; then
+            USE_EXISTING=true
+        fi
+    fi
+
+    # Verify the existing key before trusting it, so a stale/expired key
+    # doesn't slip through with a false "Sign in successful".
+    if [ "$USE_EXISTING" = true ]; then
+        echo -e "${GRAY}Verifying your existing API key...${NC}"
+        if validate_api_key "$CODEPLAIN_API_KEY"; then
             echo -e "${GREEN}✓${NC} Using existing API key."
+            SKIP_API_KEY_SETUP=true
+            API_KEY_VERIFIED=true
+        elif [ "$VALIDATION_HTTP_CODE" = "401" ]; then
+            if [ "$NONINTERACTIVE" = "1" ]; then
+                echo -e "${RED}Existing CODEPLAIN_API_KEY is invalid.${NC}"
+                echo -e "${GRAY}Set a valid CODEPLAIN_API_KEY and re-run the installer.${NC}"
+                SKIP_API_KEY_SETUP=true
+            else
+                echo -e "${RED}Your existing API key is invalid. Please enter a new one.${NC}"
+                echo ""
+                # SKIP_API_KEY_SETUP stays false: fall through to the paste flow.
+            fi
+        else
+            # Could not reach the API. Keep the existing key rather than
+            # blocking the user over a transient network issue.
+            echo -e "${GRAY}Could not verify the existing API key (could not reach ${CODEPLAIN_API_URL}). Keeping it.${NC}"
             SKIP_API_KEY_SETUP=true
         fi
     fi
@@ -144,6 +170,7 @@ if [ "$SKIP_API_KEY_SETUP" = false ]; then
             if validate_api_key "$API_KEY"; then
                 echo -e "${GREEN}✓${NC} API key verified."
                 echo ""
+                API_KEY_VERIFIED=true
                 break
             elif [ "$VALIDATION_HTTP_CODE" = "401" ]; then
                 echo -e "${RED}Invalid API key. Please make sure the full key was copied.${NC}"
@@ -212,7 +239,7 @@ cat << 'EOF'
 EOF
 echo ""
 # Only claim success when a verified API key is actually configured.
-if [ -n "${CODEPLAIN_API_KEY:-}" ]; then
+if [ "$API_KEY_VERIFIED" = true ]; then
     echo -e "${GREEN}✓ Sign in successful.${NC}"
     echo ""
 fi

--- a/install/bash/install.sh
+++ b/install/bash/install.sh
@@ -389,6 +389,23 @@ if [[ ! "${DOWNLOAD_EXAMPLES:-}" =~ ^[Nn]$ ]]; then
     run_script "examples.sh"
 fi
 
+# Final verification: make sure the installed codeplain can actually run and
+# reach the API. Only meaningful when an API key is configured, so users who
+# skipped the key are not falsely told something went wrong.
+if [ -n "${CODEPLAIN_API_KEY:-}" ]; then
+    # Ensure the freshly installed tool is findable in this session.
+    export PATH="$HOME/.local/bin:$PATH"
+    echo -e "${GRAY}Verifying your installation...${NC}"
+    if codeplain --status > /dev/null 2>&1; then
+        echo -e "${GREEN}✓${NC} Installation verified."
+    else
+        echo -e "${RED}Something went wrong during installation.${NC}"
+        echo -e "${GRAY}Please restart your terminal and try again, or reinstall with:${NC}"
+        echo -e "  uv tool install --force codeplain"
+        exit 1
+    fi
+fi
+
 # Final message
 if [ "$NONINTERACTIVE" != "1" ]; then
     clear

--- a/install/bash/install.sh
+++ b/install/bash/install.sh
@@ -5,6 +5,9 @@ set -euo pipefail
 # Base URL for additional scripts
 CODEPLAIN_SCRIPTS_BASE_URL="${CODEPLAIN_SCRIPTS_BASE_URL:-https://codeplain.ai}"
 
+# Base URL for the Codeplain API (used to verify the API key)
+CODEPLAIN_API_URL="${CODEPLAIN_API_URL:-https://api.codeplain.ai}"
+
 # Brand Colors (True Color / 24-bit)
 YELLOW='\033[38;2;224;255;110m'    # #E0FF6E
 GREEN='\033[38;2;121;252;150m'     # #79FC96
@@ -37,6 +40,30 @@ install_uv() {
     curl -LsSf https://astral.sh/uv/install.sh | sh
     # Add uv to PATH for this session
     export PATH="$HOME/.local/bin:$PATH"
+}
+
+# Trim leading/trailing whitespace (spaces, tabs, newlines, carriage returns).
+# Users often copy the API key with surrounding whitespace or newlines.
+trim_whitespace() {
+    local value="$*"
+    value="${value#"${value%%[![:space:]]*}"}"  # strip leading whitespace
+    value="${value%"${value##*[![:space:]]}"}"   # strip trailing whitespace
+    printf '%s' "$value"
+}
+
+# Verify an API key against the Codeplain API's /status endpoint.
+# Sets the global VALIDATION_HTTP_CODE and returns 0 only when the key is valid
+# (HTTP 200). This checks only the API key, nothing else about the install.
+validate_api_key() {
+    local key="$1"
+    local http_code
+    http_code=$(curl -s -o /dev/null -w "%{http_code}" \
+        --max-time 30 \
+        -X POST "${CODEPLAIN_API_URL}/status" \
+        -H "Content-Type: application/json" \
+        --data "{\"api_key\":\"${key}\"}" 2>/dev/null || true)
+    VALIDATION_HTTP_CODE="${http_code:-000}"
+    [ "$VALIDATION_HTTP_CODE" = "200" ]
 }
 
 # Check if uv is installed
@@ -100,8 +127,33 @@ if [ "$SKIP_API_KEY_SETUP" = false ]; then
     else
         echo -e "Go to ${YELLOW}https://platform.codeplain.ai${NC} and sign up to get your API key."
         echo ""
-        read -r -p "Paste your API key here: " API_KEY < /dev/tty
-        echo ""
+        # Keep prompting until we get a valid API key (or the user submits an
+        # empty value to skip). The pasted key is trimmed and verified against
+        # the Codeplain API before we accept it.
+        while true; do
+            read -r -p "Paste your API key here: " API_KEY < /dev/tty
+            echo ""
+            API_KEY="$(trim_whitespace "$API_KEY")"
+
+            # Empty input: let the user skip key setup for now.
+            if [ -z "$API_KEY" ]; then
+                break
+            fi
+
+            echo -e "${GRAY}Verifying your API key...${NC}"
+            if validate_api_key "$API_KEY"; then
+                echo -e "${GREEN}✓${NC} API key verified."
+                echo ""
+                break
+            elif [ "$VALIDATION_HTTP_CODE" = "401" ]; then
+                echo -e "${RED}Invalid API key. Please make sure the full key was copied.${NC}"
+                echo ""
+            else
+                echo -e "${RED}Could not verify the API key (could not reach ${CODEPLAIN_API_URL}).${NC}"
+                echo -e "${GRAY}Check your internet connection and try again.${NC}"
+                echo ""
+            fi
+        done
     fi
 fi
 
@@ -159,8 +211,11 @@ cat << 'EOF'
                       |_|
 EOF
 echo ""
-echo -e "${GREEN}✓ Sign in successful.${NC}"
-echo ""
+# Only claim success when a verified API key is actually configured.
+if [ -n "${CODEPLAIN_API_KEY:-}" ]; then
+    echo -e "${GREEN}✓ Sign in successful.${NC}"
+    echo ""
+fi
 echo -e "  ${WHITE}Welcome to *codeplain!${NC}"
 echo ""
 echo -e "  ${GRAY}Spec-driven, production-ready code generation${NC}"

--- a/install/powershell/install.ps1
+++ b/install/powershell/install.ps1
@@ -12,6 +12,11 @@ if (-not $env:CODEPLAIN_SCRIPTS_BASE_URL) {
     $env:CODEPLAIN_SCRIPTS_BASE_URL = "https://codeplain.ai"
 }
 
+# Base URL for the Codeplain API (used to verify the API key)
+if (-not $env:CODEPLAIN_API_URL) {
+    $env:CODEPLAIN_API_URL = "https://api.codeplain.ai"
+}
+
 # Brand Colors (True Color / 24-bit)
 $ESC = [char]27
 $YELLOW     = "$ESC[38;2;224;255;110m"      # #E0FF6E
@@ -53,6 +58,33 @@ function Install-Uv {
     } else {
         bash -c "curl -LsSf https://astral.sh/uv/install.sh | sh"
         $env:PATH = "$HOME/.local/bin:$env:PATH"
+    }
+}
+
+# Verify an API key against the Codeplain API's /status endpoint.
+# Returns a status string: "valid" (HTTP 200), "invalid" (HTTP 401), or
+# "error" (could not reach the API). This checks only the API key.
+function Test-ApiKey {
+    param([string]$Key)
+
+    $body = @{ api_key = $Key } | ConvertTo-Json -Compress
+    try {
+        $response = Invoke-WebRequest -Uri "$($env:CODEPLAIN_API_URL)/status" `
+            -Method Post `
+            -ContentType "application/json" `
+            -Body $body `
+            -TimeoutSec 30 `
+            -UseBasicParsing `
+            -ErrorAction Stop
+        if ($response.StatusCode -eq 200) { return "valid" }
+        return "error"
+    } catch {
+        $statusCode = $null
+        if ($_.Exception.Response) {
+            $statusCode = [int]$_.Exception.Response.StatusCode
+        }
+        if ($statusCode -eq 401) { return "invalid" }
+        return "error"
     }
 }
 
@@ -151,8 +183,33 @@ if (-not $skipApiKeySetup) {
     } else {
         Write-Host "Go to ${YELLOW}https://platform.codeplain.ai${NC} and sign up to get your API key."
         Write-Host ""
-        $apiKey = Read-Host "Paste your API key here"
-        Write-Host ""
+        # Keep prompting until we get a valid API key (or the user submits an
+        # empty value to skip). The pasted key is trimmed and verified against
+        # the Codeplain API before we accept it.
+        while ($true) {
+            $apiKey = (Read-Host "Paste your API key here").Trim()
+            Write-Host ""
+
+            # Empty input: let the user skip key setup for now.
+            if (-not $apiKey) {
+                break
+            }
+
+            Write-Host "${GRAY}Verifying your API key...${NC}"
+            $result = Test-ApiKey $apiKey
+            if ($result -eq "valid") {
+                Write-Host "${GREEN}✓${NC} API key verified."
+                Write-Host ""
+                break
+            } elseif ($result -eq "invalid") {
+                Write-Host "${RED}Invalid API key. Please make sure the full key was copied.${NC}"
+                Write-Host ""
+            } else {
+                Write-Host "${RED}Could not verify the API key (could not reach $($env:CODEPLAIN_API_URL)).${NC}"
+                Write-Host "${GRAY}Check your internet connection and try again.${NC}"
+                Write-Host ""
+            }
+        }
     }
 }
 
@@ -181,8 +238,11 @@ Write-Host @'
                       |_|
 '@
 Write-Host ""
-Write-Host "${GREEN}✓ Sign in successful.${NC}"
-Write-Host ""
+# Only claim success when a verified API key is actually configured.
+if ($env:CODEPLAIN_API_KEY) {
+    Write-Host "${GREEN}✓ Sign in successful.${NC}"
+    Write-Host ""
+}
 Write-Host "  ${WHITE}Welcome to *codeplain!${NC}"
 Write-Host ""
 Write-Host "  ${GRAY}Spec-driven, production-ready code generation${NC}"

--- a/install/powershell/install.ps1
+++ b/install/powershell/install.ps1
@@ -420,6 +420,28 @@ if ($downloadExamples -notmatch '^[Nn]$') {
     Invoke-SubScript "examples.ps1"
 }
 
+# Final verification: make sure the installed codeplain can actually run and
+# reach the API. Only meaningful when an API key is configured, so users who
+# skipped the key are not falsely told something went wrong.
+if ($env:CODEPLAIN_API_KEY) {
+    Write-Host "${GRAY}Verifying your installation...${NC}"
+    $verifyOk = $false
+    try {
+        & codeplain --status *> $null
+        $verifyOk = ($LASTEXITCODE -eq 0)
+    } catch {
+        $verifyOk = $false
+    }
+    if ($verifyOk) {
+        Write-Host "${GREEN}✓${NC} Installation verified."
+    } else {
+        Write-Host "${RED}Something went wrong during installation.${NC}"
+        Write-Host "${GRAY}Please restart your terminal and try again, or reinstall with:${NC}"
+        Write-Host "  uv tool install --force codeplain"
+        exit 1
+    }
+}
+
 # Final message
 if (-not $nonInteractive) { Clear-Host }
 Write-Host ""

--- a/install/powershell/install.ps1
+++ b/install/powershell/install.ps1
@@ -157,10 +157,11 @@ Write-Host ""
 
 # Check if API key already exists
 $skipApiKeySetup = $false
+$apiKeyVerified = $false
 if ($env:CODEPLAIN_API_KEY) {
+    $useExisting = $false
     if ($nonInteractive) {
-        Write-Host "${GREEN}✓${NC} Using existing CODEPLAIN_API_KEY (non-interactive mode)."
-        $skipApiKeySetup = $true
+        $useExisting = $true
     } else {
         Write-Host "  You already have an API key configured."
         Write-Host ""
@@ -170,7 +171,33 @@ if ($env:CODEPLAIN_API_KEY) {
         Write-Host ""
 
         if ($getNewKey -notmatch '^[Yy]$') {
+            $useExisting = $true
+        }
+    }
+
+    # Verify the existing key before trusting it, so a stale/expired key
+    # doesn't slip through with a false "Sign in successful".
+    if ($useExisting) {
+        Write-Host "${GRAY}Verifying your existing API key...${NC}"
+        $existingResult = Test-ApiKey $env:CODEPLAIN_API_KEY
+        if ($existingResult -eq "valid") {
             Write-Host "${GREEN}✓${NC} Using existing API key."
+            $skipApiKeySetup = $true
+            $apiKeyVerified = $true
+        } elseif ($existingResult -eq "invalid") {
+            if ($nonInteractive) {
+                Write-Host "${RED}Existing CODEPLAIN_API_KEY is invalid.${NC}"
+                Write-Host "${GRAY}Set a valid CODEPLAIN_API_KEY and re-run the installer.${NC}"
+                $skipApiKeySetup = $true
+            } else {
+                Write-Host "${RED}Your existing API key is invalid. Please enter a new one.${NC}"
+                Write-Host ""
+                # $skipApiKeySetup stays false: fall through to the paste flow.
+            }
+        } else {
+            # Could not reach the API. Keep the existing key rather than
+            # blocking the user over a transient network issue.
+            Write-Host "${GRAY}Could not verify the existing API key (could not reach $($env:CODEPLAIN_API_URL)). Keeping it.${NC}"
             $skipApiKeySetup = $true
         }
     }
@@ -200,6 +227,7 @@ if (-not $skipApiKeySetup) {
             if ($result -eq "valid") {
                 Write-Host "${GREEN}✓${NC} API key verified."
                 Write-Host ""
+                $apiKeyVerified = $true
                 break
             } elseif ($result -eq "invalid") {
                 Write-Host "${RED}Invalid API key. Please make sure the full key was copied.${NC}"
@@ -239,7 +267,7 @@ Write-Host @'
 '@
 Write-Host ""
 # Only claim success when a verified API key is actually configured.
-if ($env:CODEPLAIN_API_KEY) {
+if ($apiKeyVerified) {
     Write-Host "${GREEN}✓ Sign in successful.${NC}"
     Write-Host ""
 }

--- a/plain2code.py
+++ b/plain2code.py
@@ -327,7 +327,7 @@ def main():  # noqa: C901
             console.error(
                 "Your API key is required. Please set the CODEPLAIN_API_KEY environment variable or provide it with the --api-key argument.\n"
             )
-            return
+            sys.exit(1)
 
         if not args.api:
             args.api = "https://api.codeplain.ai"
@@ -336,6 +336,7 @@ def main():  # noqa: C901
             print_status(args.api_key, args.api, system_config.client_version)
         except Exception as e:
             console.error(f"Error fetching status: {str(e)}")
+            sys.exit(1)
         return
 
     template_dirs = file_utils.get_template_directories(args.filename, args.template_dir, DEFAULT_TEMPLATE_DIRS)


### PR DESCRIPTION
## What & why

Fixes Codeplain-ai/next-microsoft#27.

The install scripts accepted whatever the user pasted as an API key and always printed **"✓ Sign in successful"** — even for a wrong key or one copied with surrounding whitespace/newlines (as happened during testing). Nothing ever confirmed the key worked, and the installer never actually ran the `codeplain` tool to confirm the install succeeded. This PR trims and verifies the key before proceeding, and runs a final end-to-end check that the installed tool works.

## Changes

### API key verification during install (`install/bash/install.sh`, `install/powershell/install.ps1`)

- **Trim** the pasted key (strips leading/trailing spaces, tabs, newlines, CRs).
- **Verify** the key via `POST /status` with `{"api_key": "..."}` — chosen over `/connection_check` because it takes only the key and returns a clean **200 (valid) / 401 (invalid)**, checking *only* the API key and nothing else about the install.
- **Re-prompt in a loop** until a valid key is entered (or empty input to skip). Distinct messages for an invalid key vs. an unreachable API.
- **Existing key** that the user keeps (and non-interactive mode) is now verified too — a stale/expired key no longer slips through. If invalid, interactive falls through to enter a new key; non-interactive warns without claiming success. If the API is unreachable, the existing key is kept rather than locking the user out over a transient blip.
- **"Sign in successful"** now prints only when a key has actually been verified (tracked via `API_KEY_VERIFIED`), not merely when a key is present.

API base URL is overridable via `CODEPLAIN_API_URL` (defaults to `https://api.codeplain.ai`), matching the existing `CODEPLAIN_SCRIPTS_BASE_URL` pattern.

### Final installation verification (`install/bash/install.sh`, `install/powershell/install.ps1`)

- After install, run `codeplain --status` as an end-to-end check that the tool **launches, is on PATH, and can reach the API**.
- **Output is fully suppressed** — the user never sees the status payload, only ✓ "Installation verified" or a generic **"Something went wrong during installation"** followed by a non-zero exit.
- Placed before the "You're all set!" banner so a failure stops there and stays visible.
- Runs only when an API key is configured, so users who skip key setup aren't falsely alarmed.
- bash exports `~/.local/bin` onto `PATH` first so the freshly installed tool is findable; PowerShell already handles `PATH` earlier.

### Client change (`plain2code.py`)

- `codeplain --status` now **exits non-zero on failure** (missing key, or a failed status fetch); previously it always exited `0`. This is what lets the installer map the result to a reliable pass/fail. Human-visible output is unchanged.
- ⚠️ **Behavior change to flag for review:** anything scripting `codeplain --status` will now see a non-zero exit on error. This is correct CLI behavior, but it is a change.

## Testing

- `bash -n install/bash/install.sh` passes.
- Trim + `/status` verification helpers tested against a mock server: valid→200 accepted, wrong→401 rejected, whitespace-padded key trimmed & accepted, offline→000 rejected.
- Existing-key decision logic tested for all four cases (valid / invalid-interactive / invalid-noninteractive / network-error) — each produced the expected skip/verified state.
- `codeplain --status` exit codes verified against the **real API**: valid key → `0`, invalid key (401) → `1`, missing key → `1`, `--version` (offline) → `0`.
- Client quality gate: **Black, isort, flake8, mypy all clean; 240/240 tests pass.**
- PowerShell mirrors the same logic; `pwsh` was not available locally to run a syntax check.
