### PR TITLE
fix non Windows compatible date formatting to fix powershell install script

### DIFF
--- a/cli_output/status.py
+++ b/cli_output/status.py
@@ -32,7 +32,7 @@ def _display_credit_line(plan_credits: dict) -> None:
     # If naive datetime, assume UTC
     if dt.tzinfo is None:
         dt = dt.replace(tzinfo=timezone.utc)
-    formatted_date = dt.strftime("%b %-d, %Y")
+    formatted_date = f"{dt.strftime('%b')} {dt.day}, {dt.year}"
 
     # Check if expired
     now = datetime.now(timezone.utc)
@@ -62,7 +62,7 @@ def _display_bucket_credit_line(bucket: dict, label: str) -> None:
     # If naive datetime, assume UTC
     if dt.tzinfo is None:
         dt = dt.replace(tzinfo=timezone.utc)
-    formatted_date = dt.strftime("%b %-d, %Y")
+    formatted_date = f"{dt.strftime('%b')} {dt.day}, {dt.year}"
 
     # Check if expired
     now = datetime.now(timezone.utc)

--- a/install/bash/install.sh
+++ b/install/bash/install.sh
@@ -396,10 +396,12 @@ if [ -n "${CODEPLAIN_API_KEY:-}" ]; then
     # Ensure the freshly installed tool is findable in this session.
     export PATH="$HOME/.local/bin:$PATH"
     echo -e "${GRAY}Verifying your installation...${NC}"
-    if codeplain --status > /dev/null 2>&1; then
+    if verify_output=$(codeplain --status 2>&1); then
         echo -e "${GREEN}✓${NC} Installation verified."
     else
         echo -e "${RED}Something went wrong during installation.${NC}"
+        echo -e "${GRAY}Output of 'codeplain --status':${NC}"
+        echo "$verify_output"
         echo -e "${GRAY}Please restart your terminal and try again, or reinstall with:${NC}"
         echo -e "  uv tool install --force codeplain"
         exit 1

--- a/install/powershell/install.ps1
+++ b/install/powershell/install.ps1
@@ -426,16 +426,20 @@ if ($downloadExamples -notmatch '^[Nn]$') {
 if ($env:CODEPLAIN_API_KEY) {
     Write-Host "${GRAY}Verifying your installation...${NC}"
     $verifyOk = $false
+    $verifyOutput = ""
     try {
-        & codeplain --status *> $null
+        $verifyOutput = & codeplain --status 2>&1 | Out-String
         $verifyOk = ($LASTEXITCODE -eq 0)
     } catch {
+        $verifyOutput = $_ | Out-String
         $verifyOk = $false
     }
     if ($verifyOk) {
         Write-Host "${GREEN}✓${NC} Installation verified."
     } else {
         Write-Host "${RED}Something went wrong during installation.${NC}"
+        Write-Host "${GRAY}Output of 'codeplain --status':${NC}"
+        Write-Host $verifyOutput
         Write-Host "${GRAY}Please restart your terminal and try again, or reinstall with:${NC}"
         Write-Host "  uv tool install --force codeplain"
         exit 1


### PR DESCRIPTION
This fixes the windows install script which was caught broken by the [E2E tests](https://github.com/Codeplain-ai/codeplain/actions/runs/29309414194).

One of the recent changes to the bash/powershell install scripts was that they now execute `codeplain --status` to check if the installation was successful. That worked fine in bash but not on windows since the `cli_output/status.py` used a `%-d` date format which is invalid on Windows and that caused an error.

This caused a downstream error in the powershell install script but I suspect that the `codeplain` CLI tool was functional regardless of the failing script since the error happens post install.