### PR TITLE
Highlight retry/patching-loop log messages in amber

### DIFF
--- a/codeplain_REST_api.py
+++ b/codeplain_REST_api.py
@@ -67,8 +67,10 @@ class CodeplainAPI:
         connection_error_type = "Network error" if is_connection_error else "Error"
         if attempt < num_retries:
             if not silent:
-                self.console.debug(f"{connection_error_type} on attempt {attempt + 1}/{num_retries + 1}: {error}")
-                self.console.debug(f"Retrying in {retry_delay} seconds...")
+                self.console.debug(
+                    f"[#FFB454]↻ {connection_error_type} on attempt {attempt + 1}/{num_retries + 1}: {error}. "
+                    f"Retrying in {retry_delay} seconds...[/#FFB454]"
+                )
             time.sleep(retry_delay)
             # Exponential backoff
             return retry_delay * 2

--- a/render_machine/actions/fix_conformance_test.py
+++ b/render_machine/actions/fix_conformance_test.py
@@ -144,7 +144,7 @@ class FixConformanceTest(BaseAction):
             render_context.conformance_tests_running_context.conflicting_module_name = current_testing_module_name
             render_context.conformance_tests_running_context.conflicting_frid = current_testing_frid
             console.info(
-                f"Potential conflicting functionalities detected while fixing conformance tests for functionality {current_testing_frid} in module {current_testing_module_name}."
+                f"[#FFB454]Potential conflicting functionalities detected while fixing conformance tests for functionality {current_testing_frid} in module {current_testing_module_name}.[/#FFB454]"
             )
 
         if issue_reason_code == self.ISSUE_REASON_CODE_CONFORMANCE_TESTS:

--- a/render_machine/actions/render_functional_requirement.py
+++ b/render_machine/actions/render_functional_requirement.py
@@ -28,8 +28,8 @@ class RenderFunctionalRequirement(BaseAction):
 
         if render_context.frid_context.functional_requirement_render_attempts > 1:
             console.info(
-                f"Unittests could not be fixed after rendering the functionality. "
-                f"Restarting rendering functionality {render_context.frid_context.frid} from scratch."
+                f"[#FFB454]↻ Unittests could not be fixed after rendering the functionality. "
+                f"Restarting rendering functionality {render_context.frid_context.frid} from scratch.[/#FFB454]"
             )
 
         render_utils.revert_changes_for_frid(render_context)

--- a/render_machine/render_context.py
+++ b/render_machine/render_context.py
@@ -283,9 +283,10 @@ class RenderContext:
             self.dispatch_error(error_msg)
         else:
             console.info(
-                f"Failed to adjust the unit tests after implementation code was updated while fixing the conformance tests for functionality {self.frid_context.frid}."
+                f"[#FFB454]↻ Failed to adjust the unit tests after implementation code was updated while fixing the "
+                f"conformance tests for functionality {self.frid_context.frid}. "
+                f"Restarting rendering the functionality {self.frid_context.frid} from scratch.[/#FFB454]"
             )
-            console.info(f"Restarting rendering the functionality {self.frid_context.frid} from scratch.")
             self.machine.dispatch(triggers.RESTART_FRID_PROCESSING)
 
     def _on_unit_test_limit_exceeded_in_refactoring(self):

--- a/render_machine/render_utils.py
+++ b/render_machine/render_utils.py
@@ -182,12 +182,12 @@ def execute_script(  # noqa: C901
 
         if proc.returncode != 0:
             if frid is not None:
-                console.debug(
-                    f"The {script_type} script for functionality ID {frid} of module {module} has failed. Initiating the patching mode to automatically correct the discrepancies."
+                console.info(
+                    f"[#FFB454]↻ The {script_type} script for functionality ID {frid} of module {module} has failed. Initiating the patching mode to automatically correct the discrepancies.[/#FFB454]"
                 )
             else:
-                console.debug(
-                    f"The {script_type} script has failed. Initiating the patching mode to automatically correct the discrepancies."
+                console.info(
+                    f"[#FFB454]↻ The {script_type} script has failed. Initiating the patching mode to automatically correct the discrepancies.[/#FFB454]"
                 )
         else:
             if frid is not None:


### PR DESCRIPTION
## Summary
- Resolves #247. 
- Styled messages in amber (`#FFB454`) with a retry glyph (`↻`) so it's clear at a glance where the renderer is struggling and looping, mirroring the existing green success styling.