### PR TITLE
Skip plain-forge install when Node.js is unavailable

### DIFF
--- a/install/bash/install.sh
+++ b/install/bash/install.sh
@@ -312,12 +312,20 @@ fi
 
 PLAIN_FORGE_INSTALLED=false
 if [[ ! "${INSTALL_PLAIN_FORGE:-}" =~ ^[Nn]$ ]]; then
-    if command -v npx &> /dev/null; then
-        npx plain-forge install < /dev/tty
-        PLAIN_FORGE_INSTALLED=true
+    # A stale nvm/volta/asdf shim can make npx resolvable without a working
+    # Node.js behind it, so verify node actually runs before invoking npx.
+    if command -v npx &> /dev/null && node --version &> /dev/null; then
+        # The install must not abort the rest of the setup if plain-forge
+        # fails (set -e is active), so run it inside the condition.
+        if npx plain-forge install < /dev/tty; then
+            PLAIN_FORGE_INSTALLED=true
+        else
+            echo -e "${GRAY}plain-forge installation failed. You can retry later with:${NC}"
+            echo -e "  npx plain-forge install"
+        fi
         echo ""
     else
-        echo -e "${GRAY}npx not found. Install Node.js, then run:${NC}"
+        echo -e "${GRAY}Node.js not found. Skipping plain-forge. Install Node.js, then run:${NC}"
         echo -e "  npx plain-forge install"
         echo ""
     fi

--- a/install/bash/install.sh
+++ b/install/bash/install.sh
@@ -325,8 +325,11 @@ if [[ ! "${INSTALL_PLAIN_FORGE:-}" =~ ^[Nn]$ ]]; then
         fi
         echo ""
     else
-        echo -e "${GRAY}Node.js not found. Skipping plain-forge. Install Node.js, then run:${NC}"
-        echo -e "  npx plain-forge install"
+        echo -e "  ${GRAY}plain-forge brings codeplain's agentic skills to your coding agent,${NC}"
+        echo -e "  ${GRAY}but installing it requires Node.js, which was not found on this machine.${NC}"
+        echo ""
+        echo -e "  ${GRAY}If you want it, install Node.js and then run:${NC}"
+        echo -e "  ${WHITE}${BOLD}npx plain-forge install${NC}"
         echo ""
     fi
 fi

--- a/install/powershell/install.ps1
+++ b/install/powershell/install.ps1
@@ -375,8 +375,11 @@ if ($installPlainForge -notmatch '^[Nn]$') {
         }
         Write-Host ""
     } else {
-        Write-Host "${GRAY}Node.js not found. Skipping plain-forge. Install Node.js, then run:${NC}"
-        Write-Host "  npx plain-forge install"
+        Write-Host "  ${GRAY}plain-forge brings codeplain's agentic skills to your coding agent,${NC}"
+        Write-Host "  ${GRAY}but installing it requires Node.js, which was not found on this machine.${NC}"
+        Write-Host ""
+        Write-Host "  ${GRAY}If you want it, install Node.js and then run:${NC}"
+        Write-Host "  ${WHITE}${BOLD}npx plain-forge install${NC}"
         Write-Host ""
     }
 }

--- a/install/powershell/install.ps1
+++ b/install/powershell/install.ps1
@@ -347,12 +347,35 @@ if ($nonInteractive) {
 
 $plainForgeInstalled = $false
 if ($installPlainForge -notmatch '^[Nn]$') {
-    if (Get-Command npx -ErrorAction SilentlyContinue) {
-        npx plain-forge install
-        $plainForgeInstalled = $true
+    # A stale version-manager shim can make npx resolvable without a working
+    # Node.js behind it, so verify node actually runs before invoking npx.
+    $nodeWorks = $false
+    if ((Get-Command node -ErrorAction SilentlyContinue) -and (Get-Command npx -ErrorAction SilentlyContinue)) {
+        try {
+            & node --version *> $null
+            $nodeWorks = ($LASTEXITCODE -eq 0)
+        } catch {
+            $nodeWorks = $false
+        }
+    }
+    if ($nodeWorks) {
+        # A plain-forge failure must not abort the rest of the setup
+        # ($ErrorActionPreference is 'Stop').
+        try {
+            npx plain-forge install
+            if ($LASTEXITCODE -eq 0) {
+                $plainForgeInstalled = $true
+            }
+        } catch {
+            # fall through to the retry hint below
+        }
+        if (-not $plainForgeInstalled) {
+            Write-Host "${GRAY}plain-forge installation failed. You can retry later with:${NC}"
+            Write-Host "  npx plain-forge install"
+        }
         Write-Host ""
     } else {
-        Write-Host "${GRAY}npx not found. Install Node.js, then run:${NC}"
+        Write-Host "${GRAY}Node.js not found. Skipping plain-forge. Install Node.js, then run:${NC}"
         Write-Host "  npx plain-forge install"
         Write-Host ""
     }


### PR DESCRIPTION
## Problem

The installers already checked `command -v npx` / `Get-Command npx`, but that check passes when a version-manager shim (nvm, volta, asdf) is on PATH without a working Node.js behind it. When the shim then fails:

- **bash**: `set -euo pipefail` aborts the entire installer mid-flow — the plyn extension, examples, and final verification steps never run.
- **PowerShell**: `$ErrorActionPreference = 'Stop'` has the same exposure, and `$plainForgeInstalled` was set to `$true` even when the `npx` command failed.

## Fix

- Verify Node actually runs (`node --version` succeeds) instead of only checking that an `npx` shim resolves. When it doesn't, skip the step with a clear "Node.js not found. Skipping plain-forge…" message plus the manual `npx plain-forge install` hint.
- Wrap the `npx plain-forge install` call so a failure prints a retry hint and the installer continues with the remaining steps instead of aborting.
- Only mark plain-forge as installed on a zero exit code, so the existing "Next steps" screen reminds the user to install it manually whenever the step was skipped or failed.

## Testing

- `bash -n` passes on the bash installer.
- Simulated all three scenarios under `set -e` (npx missing entirely, broken shim, `npx plain-forge install` exiting non-zero) — the installer skips or continues correctly in each case and reaches the end.
- `pwsh` isn't available locally, so the PowerShell file was not syntax-checked — worth a quick run on a Windows box.