### PR TITLE
ci: ping Slack on deploys

### DIFF
--- a/.github/workflows/publish-install-script.yml
+++ b/.github/workflows/publish-install-script.yml
@@ -14,6 +14,9 @@ jobs:
     name: Upload to Cloudflare R2
     runs-on: ubuntu-latest
 
+    env:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
     steps:
       - uses: actions/checkout@v4
 
@@ -53,4 +56,18 @@ jobs:
             --endpoint-url "${R2_ENDPOINT}" \
             --content-type "text/plain"
           echo "✓ examples.ps1 uploaded to R2"
+
+      - name: Notify Slack (success)
+        if: ${{ success() && env.SLACK_WEBHOOK_URL != '' }}
+        run: |
+          curl -s -X POST "$SLACK_WEBHOOK_URL" \
+            -H 'Content-type: application/json' \
+            --data "{\"text\":\"*Codeplain Client*: Install scripts deployed to R2 :white_check_mark: (\`${GITHUB_SHA:0:7}\`, by *${{ github.actor }}*).\"}"
+
+      - name: Notify Slack (failure)
+        if: ${{ failure() && env.SLACK_WEBHOOK_URL != '' }}
+        run: |
+          curl -s -X POST "$SLACK_WEBHOOK_URL" \
+            -H 'Content-type: application/json' \
+            --data "{\"text\":\"*Codeplain Client*: Install script deploy to R2 FAILED :x: (\`${GITHUB_SHA:0:7}\`). Users may be getting a stale installer. See <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|the run log>.\"}"
 

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -15,11 +15,21 @@ jobs:
     permissions:
       contents: write
 
+    env:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
     steps:
       - uses: actions/checkout@v4
         with:
           # hatch-vcs derives the version from git tags, so we need full history.
           fetch-depth: 0
+
+      - name: Notify Slack (start)
+        if: ${{ env.SLACK_WEBHOOK_URL != '' }}
+        run: |
+          curl -s -X POST "$SLACK_WEBHOOK_URL" \
+            -H 'Content-type: application/json' \
+            --data "{\"text\":\"*Codeplain Client*: Release \`${{ github.ref_name }}\` published by *${{ github.actor }}* — building and publishing to PyPI...\"}"
 
       - name: Install uv
         # uv provisions its own Python (honoring requires-python), so no
@@ -47,6 +57,13 @@ jobs:
         run: |
           gh release upload ${{ github.ref_name }} dist/* --clobber
 
+      - name: Notify Slack (build failure)
+        if: ${{ failure() && env.SLACK_WEBHOOK_URL != '' }}
+        run: |
+          curl -s -X POST "$SLACK_WEBHOOK_URL" \
+            -H 'Content-type: application/json' \
+            --data "{\"text\":\"*Codeplain Client*: Build of \`${{ github.ref_name }}\` FAILED :x:. Nothing was published to PyPI. See <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|the run log>.\"}"
+
   publish-to-pypi:
     name: Publish to PyPI
     needs: build
@@ -59,6 +76,9 @@ jobs:
       # authenticate this run — no long-lived API token needed.
       id-token: write
 
+    env:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
     steps:
       - name: Download distribution packages
         uses: actions/download-artifact@v4
@@ -68,3 +88,17 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+
+      - name: Notify Slack (success)
+        if: ${{ success() && env.SLACK_WEBHOOK_URL != '' }}
+        run: |
+          curl -s -X POST "$SLACK_WEBHOOK_URL" \
+            -H 'Content-type: application/json' \
+            --data "{\"text\":\"*Codeplain Client*: \`${{ github.ref_name }}\` published to PyPI :white_check_mark:. Install with \`pip install --upgrade codeplain\`.\"}"
+
+      - name: Notify Slack (failure)
+        if: ${{ failure() && env.SLACK_WEBHOOK_URL != '' }}
+        run: |
+          curl -s -X POST "$SLACK_WEBHOOK_URL" \
+            -H 'Content-type: application/json' \
+            --data "{\"text\":\"*Codeplain Client*: Publishing \`${{ github.ref_name }}\` to PyPI FAILED :x:. See <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|the run log>.\"}"


### PR DESCRIPTION
## What

Adds Slack webhook pings when a deploy happens, mirroring the pattern already used in [`codeplain-api`](https://github.com/Codeplain-ai/codeplain-api/blob/main/.github/workflows/deploy.yml) (plain `curl` to `$SLACK_WEBHOOK_URL`, start / success / failure messages, prefixed with the repo name).

This repo has two deploy paths, both now covered:

**`publish-to-pypi.yml`** (release published)
- start — release tag published by whom, building
- build failure — nothing reached PyPI
- publish success — with the `pip install --upgrade codeplain` hint
- publish failure — links the run log

**`publish-install-script.yml`** (push to `main` touching `install/`)
- success / failure of the R2 upload; the failure message calls out that users may be served a stale installer

## Notes

- Every ping is guarded on `env.SLACK_WEBHOOK_URL != ''`, so forks and any repo without the secret are unaffected — no failing steps.
- Reuses the existing `SLACK_WEBHOOK_URL` secret already consumed by `nofity-slack-on-main-merge.yml`. No new secrets needed.
- Notifications are appended as steps rather than a separate job, so they inherit each job's context and don't need extra permissions.